### PR TITLE
Fix null terminator spec compliance for `CapnProto.Text`.

### DIFF
--- a/spec/CapnProto.Pointer.Struct.Spec.savi
+++ b/spec/CapnProto.Pointer.Struct.Spec.savi
@@ -102,14 +102,14 @@
       \x09\x00\x00\x00\x42\x00\x00\x00\
       \x09\x00\x00\x00\x82\x00\x00\x00\
       \x0d\x00\x00\x00\x02\x01\x00\x00\
-      Hi, Text\
-      Here's some text\
-      Here's some text with length 32!\
+      Hi Text\x00\
+      Here is a text!\x00\
+      Here's some text with length 31\x00\
       Excellent Example of a Text Set!\
       This text has no pointer, so it won't be seen.\
     ")
 
-    assert: "\(p.text(0))" == "Hi, Text"
-    assert: "\(p.text(1))" == "Here's some text"
-    assert: "\(p.text(2))" == "Here's some text with length 32!"
+    assert: "\(p.text(0))" == "Hi Text"
+    assert: "\(p.text(1))" == "Here is a text!"
+    assert: "\(p.text(2))" == "Here's some text with length 31"
     assert: "\(p.text(3))" == "" // outside the pointer region

--- a/spec/CapnProto.Pointer.StructList.Spec.savi
+++ b/spec/CapnProto.Pointer.StructList.Spec.savi
@@ -27,28 +27,28 @@
       \xde\xad\xbe\xef\xde\xad\xbe\xef\
       \xde\xad\xbe\xef\xde\xad\xbe\xef\
       \xde\xad\xbe\xef\xde\xad\xbe\xef\
-      Hello A!\
-      Hello B!\
-      Hello C!\
+      Hello A\x00\
+      Hello B\x00\
+      Hello C\x00\
       Lonely D\
     ")
 
     assert: p[0].u64(0x0) == 0x1111111111111111
     assert: p[0].u64(0x8) == 0x2222222222222222
     assert: p[0].u64(0x10) == 0 // outside the data region
-    assert: "\(p[0].text(0))" == "Hello A!"
+    assert: "\(p[0].text(0))" == "Hello A"
     assert: "\(p[0].text(1))" == "" // outside the pointers region
 
     assert: p[1].u64(0x0) == 0x3333333333333333
     assert: p[1].u64(0x8) == 0x4444444444444444
     assert: p[1].u64(0x10) == 0 // outside the data region
-    assert: "\(p[1].text(0))" == "Hello B!"
+    assert: "\(p[1].text(0))" == "Hello B"
     assert: "\(p[1].text(1))" == "" // outside the pointers region
 
     assert: p[2].u64(0x0) == 0x5555555555555555
     assert: p[2].u64(0x8) == 0x6666666666666666
     assert: p[2].u64(0x10) == 0 // outside the data region
-    assert: "\(p[2].text(0))" == "Hello C!"
+    assert: "\(p[2].text(0))" == "Hello C"
     assert: "\(p[2].text(1))" == "" // outside the pointers region
 
     assert: p[3].u64(0x0) == 0 // outside the list region

--- a/spec/CapnProto.Pointer.U8List.Spec.savi
+++ b/spec/CapnProto.Pointer.U8List.Spec.savi
@@ -14,19 +14,19 @@
   :it "reads text from a byte region"
     p = @from_segment(b"\
       \x01\x00\x00\x00\x02\x01\x00\x00\
-      Here's some text with length 32!\
+      Here's some text with length 31\x00\
       \xde\xad\xbe\xef\xde\xad\xbe\xef\
     ")
 
-    assert: "\(CapnProto.Text.new(p))" == "Here's some text with length 32!"
+    assert: "\(CapnProto.Text.new(p))" == "Here's some text with length 31"
 
   :it "can point to a prior byte region"
     p = @from_segment(b"\
       \xde\xad\xbe\xef\xde\xad\xbe\xef\
-      Here's some text\
+      Here is a text!\x00\
       \xde\xad\xbe\xef\xde\xad\xbe\xef\
       \xf1\xff\xff\xff\x82\x00\x00\x00\
       \xde\xad\xbe\xef\xde\xad\xbe\xef\
     ", 0x20)
 
-    assert: "\(CapnProto.Text.new(p))" == "Here's some text"
+    assert: "\(CapnProto.Text.new(p))" == "Here is a text!"

--- a/src/CapnProto.Pointer.U8List.savi
+++ b/src/CapnProto.Pointer.U8List.savi
@@ -80,10 +80,27 @@
 
     @_new(segments, segment, byte_offset, byte_count)
 
-  :fun each_byte
-    @_segment._bytes.each(
-      @_byte_offset.usize
-      (@_byte_offset + @_byte_count).usize
-    ) -> (byte |
-      yield byte
+  :is Indexable(U8)
+
+  :fun "[]!"(index)
+    @_segment._bytes[@_byte_offset.usize +! index]!
+
+  :fun each_with_index(from USize = 0, to = USize.max_value, stride USize = 1)
+    start = try (from +! @_byte_offset.usize | USize.max_value)
+    finish = try (to.min(@_byte_count.usize) +! @_byte_offset.usize | USize.max_value)
+
+    @_segment._bytes.each_with_index(start, finish, stride) -> (byte, index |
+      yield (byte, index)
+    )
+
+  :fun reverse_each_with_index(
+    from = USize.max_value
+    to USize = 0
+    stride USize = 1
+  ) None
+    start = try (from.min(@_byte_count.usize) +! @_byte_offset.usize | USize.max_value)
+    finish = try (to +! @_byte_offset.usize | USize.max_value)
+
+    @_segment._bytes.reverse_each_with_index(start, finish, stride) -> (byte, index |
+      yield (byte, index)
     )

--- a/src/CapnProto.Text.savi
+++ b/src/CapnProto.Text.savi
@@ -7,11 +7,20 @@
       CapnProto.Pointer.U8List._parse!(segments, segment, current_offset, value)
     )
 
-  :fun size: @_p._byte_count.usize
+  :fun size: try (@_p._byte_count.usize -! 1 | 0) // trimming off the null terminator
 
   :is IntoString
   :fun into_string_space: @size
   :fun into_string(out String'iso) String'iso
     // TODO: Do a more efficient copy here.
-    @_p.each_byte -> (byte | out.push_byte(byte))
+    @_p.each(0, @size) -> (byte | out.push_byte(byte))
     --out
+
+  :fun each_byte_with_index(
+    from USize = 0
+    to = USize.max_value
+    stride USize = 1
+  )
+    @_p.each_with_index(from, to.min(@size), stride) -> (byte, index |
+      yield (byte, index)
+    )


### PR DESCRIPTION
The Cap'n Proto encoding spec requires that every `Text` has
a null terminator encoded in it at the end of its U8 list
(for compat with old/dumb C functions that don't take a length param).

Hence, we must subtract one from the size of `CapnProto.Text`, and
we have to do an extra bounds check beyond the one already done by
`CapnProto.Pointer.U8List`, since that bounds check allows
accessing the null terminator as the final list item.