### PR TITLE
Add support for "far" pointers to other segments.

### DIFF
--- a/spec/CapnProto.Pointer.Struct.Spec.savi
+++ b/spec/CapnProto.Pointer.Struct.Spec.savi
@@ -11,6 +11,18 @@
     )
     pointer
 
+  :fun from_segments(chunks Array(Bytes), byte_offset USize = 0)
+    segments = CapnProto.Segments.new([])
+    chunks.each -> (chunk |
+      segments._list.push(CapnProto.Segment.new(chunk.clone))
+    )
+    segment = try (segments._list[0]! | CapnProto.Segment.new(b"".clone))
+    pointer = CapnProto.Pointer.Struct.empty(segments, segment)
+    assert no_error: (
+      pointer = CapnProto.Pointer.Struct.from_segments!(segments, byte_offset)
+    )
+    pointer
+
   :it "reads numeric values from the data region"
     p = @from_segment(b"\
       \x00\x00\x00\x00\x02\x00\x00\x00\
@@ -113,3 +125,48 @@
     assert: "\(p.text(1))" == "Here is a text!"
     assert: "\(p.text(2))" == "Here's some text with length 31"
     assert: "\(p.text(3))" == "" // outside the pointer region
+
+  :it "can point to a data region via a far pointer"
+    p = @from_segments([b"\
+      \x12\x00\x00\x00\x02\x00\x00\x00\
+    ", b"\
+      There's nothing meaningful in this middle segment.
+      It's just a placeholder in between the other two.
+    ", b"\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \x00\x00\x00\x00\x02\x00\x00\x00\
+      \x00\x11\x22\x33\x44\x55\x66\x77\
+      \x88\x99\xaa\xbb\xcc\xdd\xee\xff\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+    "])
+
+    assert: p.u64(0x0) == 0x7766554433221100
+    assert: p.u64(0x8) == 0xffeeddccbbaa9988
+    assert: p.u64(0x10) == 0 // outside the data region
+
+  :it "can point to a data region via a double-far pointer"
+    p = @from_segments([b"\
+      \x26\x00\x00\x00\x01\x00\x00\x00\
+    ", b"\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \x12\x00\x00\x00\x02\x00\x00\x00\
+      \x00\x00\x00\x00\x02\x00\x00\x00\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+    ", b"\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \x00\x11\x22\x33\x44\x55\x66\x77\
+      \x88\x99\xaa\xbb\xcc\xdd\xee\xff\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+    "])
+
+    assert: p.u64(0x0) == 0x7766554433221100
+    assert: p.u64(0x8) == 0xffeeddccbbaa9988
+    assert: p.u64(0x10) == 0 // outside the data region

--- a/spec/CapnProto.Pointer.StructList.Spec.savi
+++ b/spec/CapnProto.Pointer.StructList.Spec.savi
@@ -11,6 +11,18 @@
     )
     pointer
 
+  :fun from_segments(chunks Array(Bytes), byte_offset USize = 0)
+    segments = CapnProto.Segments.new([])
+    chunks.each -> (chunk |
+      segments._list.push(CapnProto.Segment.new(chunk.clone))
+    )
+    segment = try (segments._list[0]! | CapnProto.Segment.new(b"".clone))
+    pointer = CapnProto.Pointer.StructList.empty(segments, segment)
+    assert no_error: (
+      pointer = CapnProto.Pointer.StructList.from_segments!(segments, byte_offset)
+    )
+    pointer
+
   :it "reads struct values from a struct list region"
     p = @from_segment(b"\
       \x01\x00\x00\x00\x1f\x01\x00\x00\
@@ -54,3 +66,60 @@
     assert: p[3].u64(0x0) == 0 // outside the list region
     assert: p[3].u64(0x8) == 0 // outside the list region
     assert: "\(p[3].text(0))" == "" // outside the list region
+
+  :it "can point to a struct list region via a far pointer"
+    p = @from_segments([b"\
+      \x12\x00\x00\x00\x02\x00\x00\x00\
+    ", b"\
+      There's nothing meaningful in this middle segment.
+      It's just a placeholder in between the other two.
+    ", b"\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \x01\x00\x00\x00\x27\x00\x00\x00\
+      \x08\x00\x00\x00\x02\x00\x00\x00\
+      \x11\x11\x11\x11\x11\x11\x11\x11\
+      \x22\x22\x22\x22\x22\x22\x22\x22\
+      \x33\x33\x33\x33\x33\x33\x33\x33\
+      \x44\x44\x44\x44\x44\x44\x44\x44\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+    "])
+
+    assert: p[0].u64(0x0) == 0x1111111111111111
+    assert: p[0].u64(0x8) == 0x2222222222222222
+    assert: p[0].u64(0x10) == 0 // outside the data region
+    assert: p[1].u64(0x0) == 0x3333333333333333
+    assert: p[1].u64(0x8) == 0x4444444444444444
+    assert: p[1].u64(0x10) == 0 // outside the data region
+
+  :it "can point to a struct list region via a double-far pointer"
+    p = @from_segments([b"\
+      \x26\x00\x00\x00\x01\x00\x00\x00\
+    ", b"\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \x12\x00\x00\x00\x02\x00\x00\x00\
+      \x01\x00\x00\x00\x27\x00\x00\x00\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+    ", b"\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \x08\x00\x00\x00\x02\x00\x00\x00\
+      \x11\x11\x11\x11\x11\x11\x11\x11\
+      \x22\x22\x22\x22\x22\x22\x22\x22\
+      \x33\x33\x33\x33\x33\x33\x33\x33\
+      \x44\x44\x44\x44\x44\x44\x44\x44\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+    "])
+
+    assert: p[0].u64(0x0) == 0x1111111111111111
+    assert: p[0].u64(0x8) == 0x2222222222222222
+    assert: p[0].u64(0x10) == 0 // outside the data region
+    assert: p[1].u64(0x0) == 0x3333333333333333
+    assert: p[1].u64(0x8) == 0x4444444444444444
+    assert: p[1].u64(0x10) == 0 // outside the data region

--- a/spec/CapnProto.Pointer.U8List.Spec.savi
+++ b/spec/CapnProto.Pointer.U8List.Spec.savi
@@ -11,6 +11,18 @@
     )
     pointer
 
+  :fun from_segments(chunks Array(Bytes), byte_offset USize = 0)
+    segments = CapnProto.Segments.new([])
+    chunks.each -> (chunk |
+      segments._list.push(CapnProto.Segment.new(chunk.clone))
+    )
+    segment = try (segments._list[0]! | CapnProto.Segment.new(b"".clone))
+    pointer = CapnProto.Pointer.U8List.empty(segments, segment)
+    assert no_error: (
+      pointer = CapnProto.Pointer.U8List.from_segments!(segments, byte_offset)
+    )
+    pointer
+
   :it "reads text from a byte region"
     p = @from_segment(b"\
       \x01\x00\x00\x00\x02\x01\x00\x00\
@@ -30,3 +42,40 @@
     ", 0x20)
 
     assert: "\(CapnProto.Text.new(p))" == "Here is a text!"
+
+  :it "can point to a byte region via a far pointer"
+    p = @from_segments([b"\
+      \x12\x00\x00\x00\x02\x00\x00\x00\
+    ", b"\
+      There's nothing meaningful in this middle segment.
+      It's just a placeholder in between the other two.
+    ", b"\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \x01\x00\x00\x00\x02\x01\x00\x00\
+      Here's some text with length 31\x00\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+    "])
+
+    assert: "\(CapnProto.Text.new(p))" == "Here's some text with length 31"
+
+  :it "can point to a byte region via a double-far pointer"
+    p = @from_segments([b"\
+      \x26\x00\x00\x00\x01\x00\x00\x00\
+    ", b"\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \x12\x00\x00\x00\x02\x00\x00\x00\
+      \x01\x00\x00\x00\x02\x01\x00\x00\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+    ", b"\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      Here's some text with length 31\x00\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+    "])
+
+    assert: "\(CapnProto.Text.new(p))" == "Here's some text with length 31"

--- a/src/CapnProto.Pointer.Far.savi
+++ b/src/CapnProto.Pointer.Far.savi
@@ -1,0 +1,84 @@
+:struct CapnProto.Pointer.Far
+  :let _segments CapnProto.Segments
+  :let _segment CapnProto.Segment
+  :let _byte_offset U32
+  :let _override_byte_offset U32
+  :let _pointer_value U64
+  :new _new(
+    @_segments
+    @_segment
+    @_byte_offset
+    @_override_byte_offset
+    @_pointer_value
+  )
+
+  :fun non _parse!(
+    segments CapnProto.Segments
+    current_segment CapnProto.Segment
+    current_offset U32
+    value U64
+  )
+    // lsb                        far pointer                        msb
+    // +-+-+---------------------------+-------------------------------+
+    // |A|B|            C              |               D               |
+    // +-+-+---------------------------+-------------------------------+
+
+    // A (2 bits) = 2, to indicate that this is a far pointer.
+    // B (1 bit) = 0 if the landing pad is one word, 1 if it is two words.
+    //     See explanation below.
+    // C (29 bits) = Offset, in words, from the start of the target segment
+    //     to the location of the far-pointer landing-pad within that
+    //     segment.  Unsigned.
+    // D (32 bits) = ID of the target segment.  (Segments are numbered
+    //     sequentially starting from zero.)
+
+    // The 2 least significant bits (A) encode the pointer kind.
+    // Raise an error if this is not coded as a list pointer (kind two).
+    // The next bit (B) is set only in the rare case of a "double far" pointer.
+    error! unless (value.u8.bit_and(0b11) == 2)
+    is_double_far = (value.u8.bit_and(0b100) == 0b100)
+
+    // The bottom 32 bits of the value (excluding the 3 least significant bits
+    // mentioned above), encode a 29-bit unsigned integer (C) indicating the
+    // absolute offset in 8-byte words of a location within the target segment.
+    //
+    // Using a bit mask to zero out the bottom three bits, we can treat the
+    // 29-bit integer in units of 8-byte words as if it were a 32-bit integer
+    // in units of bytes, because the 3 zero bits represent a factor of 8.
+    byte_offset = value.u32.bit_and(0xFFFFFFF8)
+
+    // The upper 32-bits of the value (D), represent the segment ID, as an
+    // index into the list of segments to point to the target segment.
+    segment_id = value.bit_shr(32).u32
+    segment = segments._list[segment_id.usize]!
+
+    // The pointer value pointed to by the far pointer is retrieved from that
+    // particular byte offset within the target segment.
+    pointer_value = segment._u64!(byte_offset.u32)
+
+    // In the case of a double-far pointer, the pointer value is another far
+    // pointer, pointing to the start of the content in another segment (rather
+    // than pointing to a "landing pad" pointer as far pointers usually do).
+    // We treat this as an override on the byte offset, which we fill here.
+    override_byte_offset U32 = -1
+    if is_double_far (
+      // The landing pad of a double-far pointer is a normal far pointer.
+      // We must validate it as such, then get from it the override byte offset.
+      error! unless (pointer_value.u8.bit_and(0b111) == 0b010)
+      override_byte_offset = pointer_value.u32.bit_and(0xFFFFFFF8)
+
+      // The second half of the landing pad of a double-far pointer is a
+      // tag pointer value which is like a normal pointer to data,
+      // except that its byte offset is always zero and is thus expected
+      // to be overridden by the override byte offset gathered above.
+      tag_pointer_value = segment._u64!(byte_offset +! 8)
+
+      // We follow the second far pointer to the second target segment.
+      segment_id = pointer_value.bit_shr(32).u32
+      segment = segments._list[segment_id.usize]!
+
+      // And we treat the tag pointer value as the one that describes the data.
+      pointer_value = tag_pointer_value
+    )
+
+    @_new(segments, segment, byte_offset, override_byte_offset, pointer_value)

--- a/src/CapnProto.Pointer.Struct.savi
+++ b/src/CapnProto.Pointer.Struct.savi
@@ -23,6 +23,16 @@
     @_parse!(segments, segment, start_offset.u32, value)
 
   :fun non _parse!(segments, segment, current_offset U32, value U64)
+    // Handle the case that this may be a far pointer, pointing to the pointer.
+    override_byte_offset U32 = -1
+    try (
+      far = CapnProto.Pointer.Far._parse!(segments, segment, current_offset, value)
+      segment = far._segment
+      current_offset = far._byte_offset
+      override_byte_offset = far._override_byte_offset
+      value = far._pointer_value
+    )
+
     // lsb                      struct pointer                       msb
     // +-+-----------------------------+---------------+---------------+
     // |A|             B               |       C       |       D       |
@@ -36,7 +46,6 @@
 
     // The 2 least significant bits (A) encode the pointer kind.
     // Raise an error if this is not coded as a struct pointer (kind zero).
-    // TODO: Handle far pointers
     error! unless (value.u8.bit_and(0b11) == 0)
 
     // The bottom 32 bits of the value (excluding the 2 least significant bits)
@@ -55,6 +64,7 @@
     // or underflow is treated as a protocol error (an invalid pointer).
     offset_half = value.u32.i32
     byte_offset = (current_offset.i32 +! 8 +! offset_half +! offset_half).u32!
+    if (override_byte_offset != -1) (byte_offset = override_byte_offset)
 
     // The two upper U16 parts of the value (C and D) indicate the size
     // of the struct's data section and its pointers section, in 8-byte words.

--- a/src/CapnProto.Pointer.StructList.savi
+++ b/src/CapnProto.Pointer.StructList.savi
@@ -30,6 +30,16 @@
     @_parse!(segments, segment, start_offset.u32, value)
 
   :fun non _parse!(segments, segment, current_offset U32, value U64)
+    // Handle the case that this may be a far pointer, pointing to the pointer.
+    override_byte_offset U32 = -1
+    try (
+      far = CapnProto.Pointer.Far._parse!(segments, segment, current_offset, value)
+      segment = far._segment
+      current_offset = far._byte_offset
+      override_byte_offset = far._override_byte_offset
+      value = far._pointer_value
+    )
+
     // lsb                       list pointer                        msb
     // +-+-----------------------------+--+----------------------------+
     // |A|             B               |C |             D              |
@@ -54,7 +64,6 @@
 
     // The 2 least significant bits (A) encode the pointer kind.
     // Raise an error if this is not coded as a list pointer (kind one).
-    // TODO: Handle far pointers
     error! unless (value.u8.bit_and(0b11) == 1)
     lower_32 = value.u32.bit_xor(1)
 
@@ -83,6 +92,7 @@
     // or underflow is treated as a protocol error (an invalid pointer).
     offset_half = lower_32.i32
     tag_byte_offset = (current_offset.i32 +! offset_half +! offset_half).u32! +! 8
+    if (override_byte_offset != -1) (tag_byte_offset = override_byte_offset)
     byte_offset = tag_byte_offset +! 8
 
     // The upper 32-bits of the value, excluding the least significant 3 bits,

--- a/src/CapnProto.Pointer.U8List.savi
+++ b/src/CapnProto.Pointer.U8List.savi
@@ -19,6 +19,16 @@
     @_parse!(segments, segment, start_offset.u32, value)
 
   :fun non _parse!(segments, segment, current_offset U32, value U64)
+    // Handle the case that this may be a far pointer, pointing to the pointer.
+    override_byte_offset U32 = -1
+    try (
+      far = CapnProto.Pointer.Far._parse!(segments, segment, current_offset, value)
+      segment = far._segment
+      current_offset = far._byte_offset
+      override_byte_offset = far._override_byte_offset
+      value = far._pointer_value
+    )
+
     // lsb                       list pointer                        msb
     // +-+-----------------------------+--+----------------------------+
     // |A|             B               |C |             D              |
@@ -43,7 +53,6 @@
 
     // The 2 least significant bits (A) encode the pointer kind.
     // Raise an error if this is not coded as a list pointer (kind one).
-    // TODO: Handle far pointers
     error! unless (value.u8.bit_and(0b11) == 1)
     lower_32 = value.u32.bit_xor(1)
 
@@ -72,6 +81,7 @@
     // or underflow is treated as a protocol error (an invalid pointer).
     offset_half = lower_32.i32
     byte_offset = (current_offset.i32 +! 8 +! offset_half +! offset_half).u32!
+    if (override_byte_offset != -1) (byte_offset = override_byte_offset)
 
     // The upper 32-bits of the value, excluding the least significant 3 bits,
     // (D) indicate the number of elements in the list, which is the same as


### PR DESCRIPTION
The Cap'n Proto encoding allows a pointer-based entity residing
in different segment to be accessed via a "far" pointer
(or a "double-far" pointer) that allows the extra information
about what segment it resides in to be encoded.

Hence, all pointer `_parse!` methods have been updated to
first check if the pointer in question is a "far" pointer
by trying to use `CapnProto.Pointer.Far._parse!` on it,
which handles both "far" and "double-far" pointers,
then resume the normal specialized pointer logic on the
relevant values that were revised by the far pointer's logic.