### PR TITLE
Add `CapnProto.List.each` method.

### DIFF
--- a/spec/CapnProto.Pointer.StructList.Spec.savi
+++ b/spec/CapnProto.Pointer.StructList.Spec.savi
@@ -67,6 +67,14 @@
     assert: p[3].u64(0x8) == 0 // outside the list region
     assert: "\(p[3].text(0))" == "" // outside the list region
 
+    first_words Array(U64) = []
+    p.each -> (struct | first_words << struct.u64(0x0))
+    assert: first_words == [
+      0x1111111111111111
+      0x3333333333333333
+      0x5555555555555555
+    ]
+
   :it "can point to a struct list region via a far pointer"
     p = @from_segments([b"\
       \x12\x00\x00\x00\x02\x00\x00\x00\

--- a/src/CapnProto.List.savi
+++ b/src/CapnProto.List.savi
@@ -7,3 +7,8 @@
 
   // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
   :fun ref "[]"(n): A.from_pointer(@_p[n])
+
+  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
+  :fun ref each
+    :yields A
+    @_p.each -> (p | yield A.from_pointer(p))

--- a/src/CapnProto.Pointer.StructList.savi
+++ b/src/CapnProto.Pointer.StructList.savi
@@ -134,3 +134,15 @@
       CapnProto.Pointer.Struct.empty(@_segments, @_segment)
     )
 
+  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
+  :fun ref each
+    @_list_count.times -> (n |
+      try (
+        byte_offset = @_byte_offset
+          +! (@_data_word_count.u32 +! @_pointers_count.u32) *! n *! 8
+
+        yield CapnProto.Pointer.Struct._new(
+          @_segments, @_segment, byte_offset, @_data_word_count, @_pointers_count
+        )
+      )
+    )


### PR DESCRIPTION
This method iterates over every struct in the list.