### PR TITLE
Add `CapnProto.Segments.Reader` for reading from a byte stream.

### DIFF
--- a/manifest.savi
+++ b/manifest.savi
@@ -1,6 +1,9 @@
 :manifest lib CapnProto
   :sources "src/*.savi"
 
+  :dependency ByteStream v0
+    :from "github:savi-lang/ByteStream"
+
 :manifest bin "spec"
   :copies CapnProto
   :sources "spec/*.savi"

--- a/spec/CapnProto.Segments.Reader.Spec.savi
+++ b/spec/CapnProto.Segments.Reader.Spec.savi
@@ -1,0 +1,178 @@
+:class CapnProto.Segments.Reader.Spec
+  :is Spec
+  :const describes: "CapnProto.Segments.Reader"
+
+  :it "reads an odd number of segments, all at once (from a complete stream)"
+    reader = CapnProto.Segments.Reader.new
+    stream = ByteStream.Reader.new
+    write_stream = ByteStream.Writer.to_reader(stream)
+
+    write_stream << b"\x02\x00\x00\x00" // there will be 3 segments
+    write_stream << b"\x03\x00\x00\x00" // the first will be 3 words long
+    write_stream << b"\x04\x00\x00\x00" // the second will be 4 words long
+    write_stream << b"\x05\x00\x00\x00" // the last will be 5 words long
+    write_stream << b"\
+      \x11\x11\x11\x11\x11\x11\x11\x11\
+      \x22\x22\x22\x22\x22\x22\x22\x22\
+      \x33\x33\x33\x33\x33\x33\x33\x33\
+      \x44\x44\x44\x44\x44\x44\x44\x44\
+      \x55\x55\x55\x55\x55\x55\x55\x55\
+      \x66\x66\x66\x66\x66\x66\x66\x66\
+      \x77\x77\x77\x77\x77\x77\x77\x77\
+      \x88\x88\x88\x88\x88\x88\x88\x88\
+      \x99\x99\x99\x99\x99\x99\x99\x99\
+      \xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\
+      \xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\
+      \xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\
+    " // the segments themselves
+    write_stream << b"\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+    " // additional data that isn't actually part of the segments
+    assert no_error: write_stream.flush!
+
+    assert: reader.read!(stream) == True
+    segments = reader.take_segments
+
+    assert: segments._list[0]!._bytes == b"\
+      \x11\x11\x11\x11\x11\x11\x11\x11\
+      \x22\x22\x22\x22\x22\x22\x22\x22\
+      \x33\x33\x33\x33\x33\x33\x33\x33\
+    "
+    assert: segments._list[1]!._bytes == b"\
+      \x44\x44\x44\x44\x44\x44\x44\x44\
+      \x55\x55\x55\x55\x55\x55\x55\x55\
+      \x66\x66\x66\x66\x66\x66\x66\x66\
+      \x77\x77\x77\x77\x77\x77\x77\x77\
+    "
+    assert: segments._list[2]!._bytes == b"\
+      \x88\x88\x88\x88\x88\x88\x88\x88\
+      \x99\x99\x99\x99\x99\x99\x99\x99\
+      \xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\
+      \xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\
+      \xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\
+    "
+
+  :it "reads an even number of segments, from a frequently interrupted stream"
+    reader = CapnProto.Segments.Reader.new
+    stream = ByteStream.Reader.new
+    write_stream = ByteStream.Writer.to_reader(stream)
+
+    // There will be 2 segments, but we will write just one byte first,
+    // which isn't enough to read the full segment count indicator yet.
+    write_stream << b"\x01"
+    assert no_error: write_stream.flush!
+    assert: reader.read!(stream) == False
+    assert: reader._header.is_empty
+
+    // Now we'll write the rest of the bytes needed to know the segment count,
+    // but it's not enough yet to read the full header.
+    write_stream << b"\x00\x00\x00"
+    assert no_error: write_stream.flush!
+    assert: reader.read!(stream) == False
+    assert: reader._header.is_empty
+
+    // The first segment will be 3 words long.
+    // But this isn't the full header yet.
+    write_stream << b"\x03\x00\x00\x00"
+    assert no_error: write_stream.flush!
+    assert: reader.read!(stream) == False
+    assert: reader._header.is_empty
+
+    // The second segment will be 5 words long.
+    // We also include the header padding here (because the count is even).
+    // This concludes the full header length.
+    write_stream << b"\x05\x00\x00\x00\x00\x00\x00\x00"
+    assert no_error: write_stream.flush!
+    assert: reader.read!(stream) == False
+    assert: reader._header.is_empty == False
+    assert: reader._header.is_not_empty
+    assert: reader._expected_segment_count == 2
+    assert: reader._expected_total_size == 64
+    assert: reader._expected_segment_size(0) == 24
+    assert: reader._expected_segment_size(1) == 40
+    assert: reader._expected_segment_size(2) == 0 // this segment will not exist
+    assert: reader._segments._list.is_empty
+
+    // Now we write part of (but not all of) the first segment.
+    // It won't be ready to read yet.
+    write_stream << b"\
+      \x11\x11\x11\x11\x11\x11\x11\x11\
+      \x22\x22\x22\x22\x22\x22\x22\x22\
+    " // the segments themselves
+    assert no_error: write_stream.flush!
+    assert: reader.read!(stream) == False
+    assert: reader._segments._list.is_empty
+
+    // Now we write the rest of the first segment and part of the second one.
+    // Only the first segment will be ready to read.
+    write_stream << b"\
+      \x33\x33\x33\x33\x33\x33\x33\x33\
+      \x44\x44\x44\x44\x44\x44\x44\x44\
+      \x55\x55\x55\x55\x55\x55\x55\x55\
+      \x66\x66\x66\x66\x66\x66\x66\x66\
+    " // the segments themselves
+    assert no_error: write_stream.flush!
+    assert: reader.read!(stream) == False
+    assert: reader._segments._list.size == 1
+    assert: reader._segments._list[0]!._bytes.size == 24
+
+    // Now we write the rest of the second segment as well as some junk data.
+    write_stream << b"\
+      \x77\x77\x77\x77\x77\x77\x77\x77\
+      \x88\x88\x88\x88\x88\x88\x88\x88\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+      \xde\xad\xbe\xef\xde\xad\xbe\xef\
+    " // the segments themselves
+    assert no_error: write_stream.flush!
+    assert: reader.read!(stream) == True
+    assert: reader._header.is_empty // cleared away now that all segments are in
+    assert: reader._segments._list.size == 2
+    assert: reader._segments._list[0]!._bytes.size == 24
+    assert: reader._segments._list[1]!._bytes.size == 40
+
+    segments = reader.take_segments
+
+    assert: segments._list[0]!._bytes == b"\
+      \x11\x11\x11\x11\x11\x11\x11\x11\
+      \x22\x22\x22\x22\x22\x22\x22\x22\
+      \x33\x33\x33\x33\x33\x33\x33\x33\
+    "
+    assert: segments._list[1]!._bytes == b"\
+      \x44\x44\x44\x44\x44\x44\x44\x44\
+      \x55\x55\x55\x55\x55\x55\x55\x55\
+      \x66\x66\x66\x66\x66\x66\x66\x66\
+      \x77\x77\x77\x77\x77\x77\x77\x77\
+      \x88\x88\x88\x88\x88\x88\x88\x88\
+    "
+
+  :it "refuses to read a header whose segment count is too large"
+    reader = CapnProto.Segments.Reader.new
+    stream = ByteStream.Reader.new
+    write_stream = ByteStream.Writer.to_reader(stream)
+
+    // There will be 0x1000000 segments, which will exceed our 64 MiB budget
+    // just to read the header data alone (let alone the segments themselves).
+    write_stream << b"\0xff\xff\xff\x00"
+    assert no_error: write_stream.flush!
+    assert error: reader.read!(stream)
+    assert: reader._header.is_empty
+
+  :it "refuses to read a header announcing segments that are too large"
+    reader = CapnProto.Segments.Reader.new
+    stream = ByteStream.Reader.new
+    write_stream = ByteStream.Writer.to_reader(stream)
+
+    // There will be 4 segments, each of which will be 0x1000000 bytes
+    // (that is, 0x200000 words), which exactly matches our 64 MiB budget
+    // but will exceed it if you count the header data toward the budget too.
+    write_stream << b"\
+      \0x03\x00\x00\x00\
+      \0x00\x00\x20\x00\
+      \0x00\x00\x20\x00\
+      \0x00\x00\x20\x00\
+      \0x00\x00\x20\x00\
+    "
+    assert no_error: write_stream.flush!
+    assert error: reader.read!(stream)
+    assert: reader._header.is_empty

--- a/spec/Main.savi
+++ b/spec/Main.savi
@@ -4,4 +4,5 @@
       Spec.Run(CapnProto.Pointer.Struct.Spec).new(env)
       Spec.Run(CapnProto.Pointer.StructList.Spec).new(env)
       Spec.Run(CapnProto.Pointer.U8List.Spec).new(env)
+      Spec.Run(CapnProto.Segments.Reader.Spec).new(env)
     ])

--- a/src/CapnProto.Pointer.U8List.savi
+++ b/src/CapnProto.Pointer.U8List.savi
@@ -96,8 +96,8 @@
     @_segment._bytes[@_byte_offset.usize +! index]!
 
   :fun each_with_index(from USize = 0, to = USize.max_value, stride USize = 1)
-    start = try (from +! @_byte_offset.usize | USize.max_value)
-    finish = try (to.min(@_byte_count.usize) +! @_byte_offset.usize | USize.max_value)
+    start = from.saturating_add(@_byte_offset.usize)
+    finish = to.min(@_byte_count.usize).saturating_add(@_byte_offset.usize)
 
     @_segment._bytes.each_with_index(start, finish, stride) -> (byte, index |
       yield (byte, index)
@@ -108,8 +108,8 @@
     to USize = 0
     stride USize = 1
   ) None
-    start = try (from.min(@_byte_count.usize) +! @_byte_offset.usize | USize.max_value)
-    finish = try (to +! @_byte_offset.usize | USize.max_value)
+    start = from.min(@_byte_count.usize).saturating_add(@_byte_offset.usize)
+    finish = to.saturating_add(@_byte_offset.usize)
 
     @_segment._bytes.reverse_each_with_index(start, finish, stride) -> (byte, index |
       yield (byte, index)

--- a/src/CapnProto.Segment.savi
+++ b/src/CapnProto.Segment.savi
@@ -6,7 +6,3 @@
   :fun _u16!(offset U32): @_bytes.read_native_u16!(offset.usize).le_to_native
   :fun _u32!(offset U32): @_bytes.read_native_u32!(offset.usize).le_to_native
   :fun _u64!(offset U32): @_bytes.read_native_u64!(offset.usize).le_to_native
-
-:struct CapnProto.Segments
-  :let _list Array(CapnProto.Segment)'ref
-  :new (@_list)

--- a/src/CapnProto.Segments.savi
+++ b/src/CapnProto.Segments.savi
@@ -1,0 +1,121 @@
+:struct CapnProto.Segments
+  :let _list Array(CapnProto.Segment)'ref
+  :new (@_list)
+
+:class CapnProto.Segments.Reader
+  :var _header: b""
+  :var _segments: CapnProto.Segments.new([]) // TODO: iso
+
+  :fun ref take_segments: @_segments <<= CapnProto.Segments.new([])
+
+  :: The maximum total size that the segment buffers are allowed to allocate.
+  ::
+  :: This security limit should be configured to a size that is large enough
+  :: for any legitimate application messages, but small enough so as to not
+  :: allow attackers to cause out-of-memory errors by announcing large sizes.
+  :const max_total_size USize: 0x4000000 // 64 MiB
+
+  :: Based on the captured header, determine the expected segment count.
+  :: Returns zero if no header has been captured yet.
+  :fun _expected_segment_count USize
+    try (@_header.read_native_u32!(0).usize + 1 | 0)
+
+  :: Based on the captured header, determine the expected size for a segment.
+  :: Returns zero if no header has been captured yet.
+  :fun _expected_segment_size(segment_id USize) USize
+    try (
+      @_header.read_native_u32!((segment_id + 1) * 4)
+        .usize
+        .saturating_multiply(8)
+    |
+      0
+    )
+
+  :: Based on the captured header, determine the expected size for all segments.
+  :: Returns zero if no header has been captured yet.
+  :fun _expected_total_size USize
+    total USize = 0
+    @_expected_segment_count.times -> (segment_id |
+      total += @_expected_segment_size(segment_id)
+    )
+    total
+
+  :: Read segments from the given byte stream.
+  ::
+  :: Returns True if all of the segments have been fully populated into memory.
+  :: Returns False if still waiting for more bytes to arrive in the stream.
+  ::
+  :: Raises an error if continuing to read the segments into memory would
+  :: exceed the security limit imposed by the `max_total_size` constant.
+  :fun ref read!(stream ByteStream.Reader) Bool
+    // First, if we haven't read the header yet, read it now.
+    if @_header.is_empty (
+      if !@_read_header!(stream) (return False)
+    )
+
+    // Then read any available segments from the stream.
+    @_read_all_segments(stream)
+
+  :: Read the "segment table" header portion preceding and framing the segments.
+  ::
+  :: Returns False if there aren't enough bytes to read the complete header yet.
+  :: Raises an error if the header causes a max size violation.
+  :fun ref _read_header!(stream ByteStream.Reader) Bool
+    // Determine the number of segments that will be in the segment table.
+    // Return False if there aren't enough bytes yet to read the first U32.
+    segment_count = try (
+      stream.peek_native_u32!.le_to_native +! 1
+    |
+      return False
+    )
+
+    // Determine the number of bytes to expect in the segment table header.
+    // Raise an error if even the header alone will exceed our max size.
+    header_has_padding = segment_count.is_even
+    header_size =
+      (segment_count.usize +! 1) *! 4 +! if header_has_padding (4 | 0)
+    error! if (header_size > @max_total_size)
+
+    // Extract the header bytes into our field for storage later.
+    // Return False if the complete header bytes aren't available yet.
+    @_header = try (
+      stream.advance!(header_size).extract_token
+    |
+      return False
+    )
+
+    // Now that we have the header, we can calculate the expected total size.
+    // We'll reserve enough space in the stream buffer for that many bytes.
+    // But first, raise an error if the size would violate our security limit.
+    expected_total_size = @_expected_total_size
+    if (expected_total_size + header_size > @max_total_size) (
+      // Error out, but first clear the header so that we'll be ready to
+      // accept a different message header the next time we try to read.
+      @_header = b""
+      error!
+    )
+    stream.reserve_bytes_ahead(expected_total_size)
+
+    True
+
+  :fun ref _read_all_segments(stream ByteStream.Reader) Bool
+    // Keep reading segments one by one until we've collected them all.
+    // The header informs us about the size of each segment.
+    count = @_expected_segment_count
+    while (@_segments._list.size < count) (
+      segment_id = @_segments._list.size
+      segment_size = @_expected_segment_size(segment_id)
+      try (
+        @_segments._list << CapnProto.Segment.new(
+          stream.advance!(segment_size).extract_token
+        )
+      |
+        return False
+      )
+    )
+
+    // Nice, we successfully read all the segments. Clear the header,
+    // so that we'll be ready to read in a different set of segments next time.
+    @_header = b""
+
+    True


### PR DESCRIPTION
This includes the logic needed to read the framing header data at
the start of the stream to determine sizes, to prepare the incoming
buffers to read the correct amount, and to actually read in the
segment data into a `CapnProto.Segments` object in a zero-copy way.

It also includes a mechanism for limiting to total size per message,
to avoid allowing an attacker to cause the reader to over-allocate
and crash due to an out of memory error. This limit is intended
to be configurable once Savi has the compile-time mechanism in
place for doing so (see https://github.com/savi-lang/savi/issues/161).