### PR TITLE
Use bot token on `release` CI workflow.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,7 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.version-tag }}
           generate_release_notes: true
+          token: ${{ secrets.BOT_GITHUB_TOKEN }} # (to allow triggering other workflows)
           fail_on_unmatched_files: true
           files: |
             ${{ steps.capnpc-savi.outputs.tarball-directory }}/*


### PR DESCRIPTION
This allows it to trigger the `library-release-notify` workflow.

The default token used for GitHub actions doesn't allow an event associated with that token to trigger another CI workflow.