### PR TITLE
Distinguish between Builder and read-only struct views.

### DIFF
--- a/spec/CapnProto.Pointer.Struct.Builder.Spec.savi
+++ b/spec/CapnProto.Pointer.Struct.Builder.Spec.savi
@@ -1,0 +1,35 @@
+:class CapnProto.Pointer.Struct.Builder.Spec
+  :is Spec
+  :const describes: "CapnProto.Pointer.Struct.Builder"
+
+  :fun init_with_size(data_word_count U16, pointers_count U16)
+    byte_size = (data_word_count + pointers_count).usize * 8
+    chunk = Bytes.new.fill_with_zeros(0, byte_size)
+    segment = CapnProto.Segment.new(chunk)
+    segments = CapnProto.Segments.new([segment])
+    CapnProto.Pointer.Struct.Builder._new(
+      segments, segment, 0, data_word_count, pointers_count
+    )
+
+  :it "writes and reads numeric values in the data region"
+    p = @init_with_size(0x10, 0)
+
+    assert: p.set_u64(0x0, 0xbeeedeeed000daaa) == 0xbeeedeeed000daaa
+    assert: p.set_u64(0x8, 0xb333d333d0ffdaff) == 0xb333d333d0ffdaff
+    assert: p.u64(0x0) == 0xbeeedeeed000daaa
+    assert: p.u64(0x8) == 0xb333d333d0ffdaff
+
+    assert: p.set_u32(0x0, 0xbaaafaaa) == 0xbaaafaaa
+    assert: p.set_u32(0x4, 0xb000f000) == 0xb000f000
+    assert: p.u64(0x0) == 0xb000f000baaafaaa
+
+    assert: p.set_u16(0x0, 0x1add) == 0x1add
+    assert: p.set_u16(0x2, 0xbadd) == 0xbadd
+    assert: p.u32(0x0) == 0xbadd1add
+
+    assert: p.set_u8(0x0, 0xbe) == 0xbe
+    assert: p.set_u8(0x1, 0xba) == 0xba
+    assert: p.u16(0x0) == 0xbabe
+
+    assert: p.u64(0x0) == 0xb000f000baddbabe
+    assert: p.u64(0x8) == 0xb333d333d0ffdaff

--- a/spec/CapnProto.Pointer.Struct.Spec.savi
+++ b/spec/CapnProto.Pointer.Struct.Spec.savi
@@ -63,26 +63,6 @@
     assert no_error: p.assert_union!(0x2, 0x3322)
     assert    error: p.assert_union!(0x2, 0x3300)
 
-    assert: p.set_u64(0x0, 0xbeeedeeed000daaa) == 0xbeeedeeed000daaa
-    assert: p.set_u64(0x8, 0xb333d333d0ffdaff) == 0xb333d333d0ffdaff
-    assert: p.set_u64(0x10, 0xdeadbeefdeadbeef) == 0xdeadbeefdeadbeef // outside
-    assert: p.u64(0x0) == 0xbeeedeeed000daaa
-    assert: p.u64(0x8) == 0xb333d333d0ffdaff
-    assert: p.set_u32(0x0, 0xbaaafaaa) == 0xbaaafaaa
-    assert: p.set_u32(0x4, 0xb000f000) == 0xb000f000
-    assert: p.set_u32(0x10, 0xdeadbeef) == 0xdeadbeef // outside
-    assert: p.u64(0x0) == 0xb000f000baaafaaa
-    assert: p.set_u16(0x0, 0x1add) == 0x1add
-    assert: p.set_u16(0x2, 0xbadd) == 0xbadd
-    assert: p.set_u16(0x10, 0xdead) == 0xdead // outside
-    assert: p.u32(0x0) == 0xbadd1add
-    assert: p.set_u8(0x0, 0xbe) == 0xbe
-    assert: p.set_u8(0x1, 0xba) == 0xba
-    assert: p.set_u16(0x10, 0xdd) == 0xdd // outside
-    assert: p.u16(0x0) == 0xbabe
-    assert: p.u64(0x0) == 0xb000f000baddbabe
-    assert: p.u64(0x8) == 0xb333d333d0ffdaff
-
   :it "can point to a prior data region"
     p = @from_segment(b"\
       \x00\x11\x22\x33\x44\x55\x66\x77\

--- a/spec/Main.savi
+++ b/spec/Main.savi
@@ -2,6 +2,7 @@
   :new (env Env)
     Spec.Process.run(env, [
       Spec.Run(CapnProto.Pointer.Struct.Spec).new(env)
+      Spec.Run(CapnProto.Pointer.Struct.Builder.Spec).new(env)
       Spec.Run(CapnProto.Pointer.StructList.Spec).new(env)
       Spec.Run(CapnProto.Pointer.U8List.Spec).new(env)
       Spec.Run(CapnProto.Segments.Reader.Spec).new(env)

--- a/src/CapnProto.List.savi
+++ b/src/CapnProto.List.savi
@@ -12,3 +12,18 @@
   :fun ref each
     :yields A
     @_p.each -> (p | yield A.from_pointer(p))
+
+:trait _FromStructPointerBuilder
+  :new from_pointer(pointer CapnProto.Pointer.Struct.Builder)
+
+:struct CapnProto.List.Builder(A _FromStructPointerBuilder)
+  :let _p CapnProto.Pointer.StructList.Builder
+  :new (@_p)
+
+  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
+  :fun ref "[]"(n): A.from_pointer(@_p[n])
+
+  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
+  :fun ref each
+    :yields A
+    @_p.each -> (p | yield A.from_pointer(p))

--- a/src/CapnProto.Meta.capnp.savi
+++ b/src/CapnProto.Meta.capnp.savi
@@ -7,15 +7,12 @@
   :new from_pointer(@_p)
 
   :fun id: @_p.u64(0x0)
-  :fun ref "id="(new_value U64): @_p.set_u64(0x0, new_value)
 
   :fun ref display_name: @_p.text(0)
 
   :fun display_name_prefix_length: @_p.u32(0x8)
-  :fun ref "display_name_prefix_length="(new_value U32): @_p.set_u32(0x8, new_value)
 
   :fun scope_id: @_p.u64(0x10)
-  :fun ref "scope_id="(new_value U64): @_p.set_u64(0x10, new_value)
 
   :fun ref nested_nodes: CapnProto.List(CapnProto.Meta.Node.NestedNode).new(@_p.list(1))
 
@@ -42,29 +39,22 @@
   :fun ref parameters: CapnProto.List(CapnProto.Meta.Node.Parameter).new(@_p.list(5))
 
   :fun is_generic: @_p.bool(0x24, 0b00000001)
-  :fun ref "is_generic="(new_value Bool): @_p.set_bool(0x24, 0b00000001, new_value)
 
 :struct CapnProto.Meta.Node.AS_struct
   :let _p CapnProto.Pointer.Struct
   :new from_pointer(@_p)
 
   :fun data_word_count: @_p.u16(0xe)
-  :fun ref "data_word_count="(new_value U16): @_p.set_u16(0xe, new_value)
 
   :fun pointer_count: @_p.u16(0x18)
-  :fun ref "pointer_count="(new_value U16): @_p.set_u16(0x18, new_value)
 
   :fun preferred_list_encoding: CapnProto.Meta.ElementSize._new(@_p.u16(0x1a))
-  :fun ref "preferred_list_encoding="(new_value CapnProto.Meta.ElementSize): @_p.set_u16(0x1a, new_value.u16)
 
   :fun is_group: @_p.bool(0x1c, 0b00000001)
-  :fun ref "is_group="(new_value Bool): @_p.set_bool(0x1c, 0b00000001, new_value)
 
   :fun discriminant_count: @_p.u16(0x1e)
-  :fun ref "discriminant_count="(new_value U16): @_p.set_u16(0x1e, new_value)
 
   :fun discriminant_offset: @_p.u32(0x20)
-  :fun ref "discriminant_offset="(new_value U32): @_p.set_u32(0x20, new_value)
 
   :fun ref fields: CapnProto.List(CapnProto.Meta.Field).new(@_p.list(3))
 
@@ -97,40 +87,28 @@
   :fun ref type: CapnProto.Meta.Type.from_pointer(@_p.struct(3))
 
   :fun targets_file: @_p.bool(0xe, 0b00000001)
-  :fun ref "targets_file="(new_value Bool): @_p.set_bool(0xe, 0b00000001, new_value)
 
   :fun targets_const: @_p.bool(0xe, 0b00000010)
-  :fun ref "targets_const="(new_value Bool): @_p.set_bool(0xe, 0b00000010, new_value)
 
   :fun targets_enum: @_p.bool(0xe, 0b00000100)
-  :fun ref "targets_enum="(new_value Bool): @_p.set_bool(0xe, 0b00000100, new_value)
 
   :fun targets_enumerant: @_p.bool(0xe, 0b00001000)
-  :fun ref "targets_enumerant="(new_value Bool): @_p.set_bool(0xe, 0b00001000, new_value)
 
   :fun targets_struct: @_p.bool(0xe, 0b00010000)
-  :fun ref "targets_struct="(new_value Bool): @_p.set_bool(0xe, 0b00010000, new_value)
 
   :fun targets_field: @_p.bool(0xe, 0b00100000)
-  :fun ref "targets_field="(new_value Bool): @_p.set_bool(0xe, 0b00100000, new_value)
 
   :fun targets_union: @_p.bool(0xe, 0b01000000)
-  :fun ref "targets_union="(new_value Bool): @_p.set_bool(0xe, 0b01000000, new_value)
 
   :fun targets_group: @_p.bool(0xe, 0b10000000)
-  :fun ref "targets_group="(new_value Bool): @_p.set_bool(0xe, 0b10000000, new_value)
 
   :fun targets_interface: @_p.bool(0xf, 0b00000001)
-  :fun ref "targets_interface="(new_value Bool): @_p.set_bool(0xf, 0b00000001, new_value)
 
   :fun targets_method: @_p.bool(0xf, 0b00000010)
-  :fun ref "targets_method="(new_value Bool): @_p.set_bool(0xf, 0b00000010, new_value)
 
   :fun targets_param: @_p.bool(0xf, 0b00000100)
-  :fun ref "targets_param="(new_value Bool): @_p.set_bool(0xf, 0b00000100, new_value)
 
   :fun targets_annotation: @_p.bool(0xf, 0b00001000)
-  :fun ref "targets_annotation="(new_value Bool): @_p.set_bool(0xf, 0b00001000, new_value)
 
 :struct CapnProto.Meta.Node.Parameter
   :let _p CapnProto.Pointer.Struct
@@ -145,7 +123,6 @@
   :fun ref name: @_p.text(0)
 
   :fun id: @_p.u64(0x0)
-  :fun ref "id="(new_value U64): @_p.set_u64(0x0, new_value)
 
 :struct CapnProto.Meta.Field
   :let _p CapnProto.Pointer.Struct
@@ -156,12 +133,10 @@
   :fun ref name: @_p.text(0)
 
   :fun code_order: @_p.u16(0x0)
-  :fun ref "code_order="(new_value U16): @_p.set_u16(0x0, new_value)
 
   :fun ref annotations: CapnProto.List(CapnProto.Meta.Annotation).new(@_p.list(1))
 
   :fun discriminant_value: @_p.u16(0x2).bit_xor(65535)
-  :fun ref "discriminant_value="(new_value U16): @_p.set_u16(0x2, new_value.bit_xor(65535))
 
   :fun is_slot: @_p.check_union(0x8, 0)
   :fun ref slot!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Field.AS_slot.from_pointer(@_p)
@@ -176,21 +151,18 @@
   :new from_pointer(@_p)
 
   :fun offset: @_p.u32(0x4)
-  :fun ref "offset="(new_value U32): @_p.set_u32(0x4, new_value)
 
   :fun ref type: CapnProto.Meta.Type.from_pointer(@_p.struct(2))
 
   :fun ref default_value: CapnProto.Meta.Value.from_pointer(@_p.struct(3))
 
   :fun had_explicit_default: @_p.bool(0x10, 0b00000001)
-  :fun ref "had_explicit_default="(new_value Bool): @_p.set_bool(0x10, 0b00000001, new_value)
 
 :struct CapnProto.Meta.Field.AS_group
   :let _p CapnProto.Pointer.Struct
   :new from_pointer(@_p)
 
   :fun type_id: @_p.u64(0x10)
-  :fun ref "type_id="(new_value U64): @_p.set_u64(0x10, new_value)
 
 :struct CapnProto.Meta.Field.AS_ordinal
   :let _p CapnProto.Pointer.Struct
@@ -209,7 +181,6 @@
   :fun ref name: @_p.text(0)
 
   :fun code_order: @_p.u16(0x0)
-  :fun ref "code_order="(new_value U16): @_p.set_u16(0x0, new_value)
 
   :fun ref annotations: CapnProto.List(CapnProto.Meta.Annotation).new(@_p.list(1))
 
@@ -218,7 +189,6 @@
   :new from_pointer(@_p)
 
   :fun id: @_p.u64(0x0)
-  :fun ref "id="(new_value U64): @_p.set_u64(0x0, new_value)
 
   :fun ref brand: CapnProto.Meta.Brand.from_pointer(@_p.struct(0))
 
@@ -229,13 +199,10 @@
   :fun ref name: @_p.text(0)
 
   :fun code_order: @_p.u16(0x0)
-  :fun ref "code_order="(new_value U16): @_p.set_u16(0x0, new_value)
 
   :fun param_struct_type: @_p.u64(0x8)
-  :fun ref "param_struct_type="(new_value U64): @_p.set_u64(0x8, new_value)
 
   :fun result_struct_type: @_p.u64(0x10)
-  :fun ref "result_struct_type="(new_value U64): @_p.set_u64(0x10, new_value)
 
   :fun ref annotations: CapnProto.List(CapnProto.Meta.Annotation).new(@_p.list(1))
 
@@ -317,7 +284,6 @@
   :new from_pointer(@_p)
 
   :fun type_id: @_p.u64(0x8)
-  :fun ref "type_id="(new_value U64): @_p.set_u64(0x8, new_value)
 
   :fun ref brand: CapnProto.Meta.Brand.from_pointer(@_p.struct(0))
 
@@ -326,7 +292,6 @@
   :new from_pointer(@_p)
 
   :fun type_id: @_p.u64(0x8)
-  :fun ref "type_id="(new_value U64): @_p.set_u64(0x8, new_value)
 
   :fun ref brand: CapnProto.Meta.Brand.from_pointer(@_p.struct(0))
 
@@ -335,7 +300,6 @@
   :new from_pointer(@_p)
 
   :fun type_id: @_p.u64(0x8)
-  :fun ref "type_id="(new_value U64): @_p.set_u64(0x8, new_value)
 
   :fun ref brand: CapnProto.Meta.Brand.from_pointer(@_p.struct(0))
 
@@ -373,17 +337,14 @@
   :new from_pointer(@_p)
 
   :fun scope_id: @_p.u64(0x10)
-  :fun ref "scope_id="(new_value U64): @_p.set_u64(0x10, new_value)
 
   :fun parameter_index: @_p.u16(0xa)
-  :fun ref "parameter_index="(new_value U16): @_p.set_u16(0xa, new_value)
 
 :struct CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter
   :let _p CapnProto.Pointer.Struct
   :new from_pointer(@_p)
 
   :fun parameter_index: @_p.u16(0xa)
-  :fun ref "parameter_index="(new_value U16): @_p.set_u16(0xa, new_value)
 
 :struct CapnProto.Meta.Brand
   :let _p CapnProto.Pointer.Struct
@@ -396,7 +357,6 @@
   :new from_pointer(@_p)
 
   :fun scope_id: @_p.u64(0x0)
-  :fun ref "scope_id="(new_value U64): @_p.set_u64(0x0, new_value)
 
   :fun is_bind: @_p.check_union(0x8, 0)
   :fun ref bind!: @_p.assert_union!(0x8, 0), CapnProto.List(CapnProto.Meta.Brand.Binding).new(@_p.list(0))
@@ -480,7 +440,6 @@
   :new from_pointer(@_p)
 
   :fun id: @_p.u64(0x0)
-  :fun ref "id="(new_value U64): @_p.set_u64(0x0, new_value)
 
   :fun ref value: CapnProto.Meta.Value.from_pointer(@_p.struct(0))
 
@@ -518,7 +477,6 @@
   :new from_pointer(@_p)
 
   :fun id: @_p.u64(0x0)
-  :fun ref "id="(new_value U64): @_p.set_u64(0x0, new_value)
 
   :fun ref filename: @_p.text(0)
 
@@ -526,6 +484,517 @@
 
 :struct CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import
   :let _p CapnProto.Pointer.Struct
+  :new from_pointer(@_p)
+
+  :fun id: @_p.u64(0x0)
+
+  :fun ref name: @_p.text(0)
+
+:struct CapnProto.Meta.Node.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun id: @_p.u64(0x0)
+  :fun ref "id="(new_value U64): @_p.set_u64(0x0, new_value)
+
+  :fun ref display_name: @_p.text(0)
+
+  :fun display_name_prefix_length: @_p.u32(0x8)
+  :fun ref "display_name_prefix_length="(new_value U32): @_p.set_u32(0x8, new_value)
+
+  :fun scope_id: @_p.u64(0x10)
+  :fun ref "scope_id="(new_value U64): @_p.set_u64(0x10, new_value)
+
+  :fun ref nested_nodes: CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).new(@_p.list(1))
+
+  :fun ref annotations: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).new(@_p.list(2))
+
+  :fun is_file: @_p.check_union(0xc, 0)
+  :fun file!: @_p.assert_union!(0xc, 0), None
+
+  :fun is_struct: @_p.check_union(0xc, 1)
+  :fun ref struct!: @_p.assert_union!(0xc, 1), CapnProto.Meta.Node.AS_struct.Builder.from_pointer(@_p)
+
+  :fun is_enum: @_p.check_union(0xc, 2)
+  :fun ref enum!: @_p.assert_union!(0xc, 2), CapnProto.Meta.Node.AS_enum.Builder.from_pointer(@_p)
+
+  :fun is_interface: @_p.check_union(0xc, 3)
+  :fun ref interface!: @_p.assert_union!(0xc, 3), CapnProto.Meta.Node.AS_interface.Builder.from_pointer(@_p)
+
+  :fun is_const: @_p.check_union(0xc, 4)
+  :fun ref const!: @_p.assert_union!(0xc, 4), CapnProto.Meta.Node.AS_const.Builder.from_pointer(@_p)
+
+  :fun is_annotation: @_p.check_union(0xc, 5)
+  :fun ref annotation!: @_p.assert_union!(0xc, 5), CapnProto.Meta.Node.AS_annotation.Builder.from_pointer(@_p)
+
+  :fun ref parameters: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).new(@_p.list(5))
+
+  :fun is_generic: @_p.bool(0x24, 0b00000001)
+  :fun ref "is_generic="(new_value Bool): @_p.set_bool(0x24, 0b00000001, new_value)
+
+:struct CapnProto.Meta.Node.AS_struct.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun data_word_count: @_p.u16(0xe)
+  :fun ref "data_word_count="(new_value U16): @_p.set_u16(0xe, new_value)
+
+  :fun pointer_count: @_p.u16(0x18)
+  :fun ref "pointer_count="(new_value U16): @_p.set_u16(0x18, new_value)
+
+  :fun preferred_list_encoding: CapnProto.Meta.ElementSize._new(@_p.u16(0x1a))
+  :fun ref "preferred_list_encoding="(new_value CapnProto.Meta.ElementSize): @_p.set_u16(0x1a, new_value.u16)
+
+  :fun is_group: @_p.bool(0x1c, 0b00000001)
+  :fun ref "is_group="(new_value Bool): @_p.set_bool(0x1c, 0b00000001, new_value)
+
+  :fun discriminant_count: @_p.u16(0x1e)
+  :fun ref "discriminant_count="(new_value U16): @_p.set_u16(0x1e, new_value)
+
+  :fun discriminant_offset: @_p.u32(0x20)
+  :fun ref "discriminant_offset="(new_value U32): @_p.set_u32(0x20, new_value)
+
+  :fun ref fields: CapnProto.List.Builder(CapnProto.Meta.Field.Builder).new(@_p.list(3))
+
+:struct CapnProto.Meta.Node.AS_enum.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun ref enumerants: CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).new(@_p.list(3))
+
+:struct CapnProto.Meta.Node.AS_interface.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun ref methods: CapnProto.List.Builder(CapnProto.Meta.Method.Builder).new(@_p.list(3))
+
+  :fun ref superclasses: CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).new(@_p.list(4))
+
+:struct CapnProto.Meta.Node.AS_const.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(3))
+
+  :fun ref value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(4))
+
+:struct CapnProto.Meta.Node.AS_annotation.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(3))
+
+  :fun targets_file: @_p.bool(0xe, 0b00000001)
+  :fun ref "targets_file="(new_value Bool): @_p.set_bool(0xe, 0b00000001, new_value)
+
+  :fun targets_const: @_p.bool(0xe, 0b00000010)
+  :fun ref "targets_const="(new_value Bool): @_p.set_bool(0xe, 0b00000010, new_value)
+
+  :fun targets_enum: @_p.bool(0xe, 0b00000100)
+  :fun ref "targets_enum="(new_value Bool): @_p.set_bool(0xe, 0b00000100, new_value)
+
+  :fun targets_enumerant: @_p.bool(0xe, 0b00001000)
+  :fun ref "targets_enumerant="(new_value Bool): @_p.set_bool(0xe, 0b00001000, new_value)
+
+  :fun targets_struct: @_p.bool(0xe, 0b00010000)
+  :fun ref "targets_struct="(new_value Bool): @_p.set_bool(0xe, 0b00010000, new_value)
+
+  :fun targets_field: @_p.bool(0xe, 0b00100000)
+  :fun ref "targets_field="(new_value Bool): @_p.set_bool(0xe, 0b00100000, new_value)
+
+  :fun targets_union: @_p.bool(0xe, 0b01000000)
+  :fun ref "targets_union="(new_value Bool): @_p.set_bool(0xe, 0b01000000, new_value)
+
+  :fun targets_group: @_p.bool(0xe, 0b10000000)
+  :fun ref "targets_group="(new_value Bool): @_p.set_bool(0xe, 0b10000000, new_value)
+
+  :fun targets_interface: @_p.bool(0xf, 0b00000001)
+  :fun ref "targets_interface="(new_value Bool): @_p.set_bool(0xf, 0b00000001, new_value)
+
+  :fun targets_method: @_p.bool(0xf, 0b00000010)
+  :fun ref "targets_method="(new_value Bool): @_p.set_bool(0xf, 0b00000010, new_value)
+
+  :fun targets_param: @_p.bool(0xf, 0b00000100)
+  :fun ref "targets_param="(new_value Bool): @_p.set_bool(0xf, 0b00000100, new_value)
+
+  :fun targets_annotation: @_p.bool(0xf, 0b00001000)
+  :fun ref "targets_annotation="(new_value Bool): @_p.set_bool(0xf, 0b00001000, new_value)
+
+:struct CapnProto.Meta.Node.Parameter.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun ref name: @_p.text(0)
+
+:struct CapnProto.Meta.Node.NestedNode.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun ref name: @_p.text(0)
+
+  :fun id: @_p.u64(0x0)
+  :fun ref "id="(new_value U64): @_p.set_u64(0x0, new_value)
+
+:struct CapnProto.Meta.Field.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :const no_discriminant U16: 65535
+
+  :fun ref name: @_p.text(0)
+
+  :fun code_order: @_p.u16(0x0)
+  :fun ref "code_order="(new_value U16): @_p.set_u16(0x0, new_value)
+
+  :fun ref annotations: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).new(@_p.list(1))
+
+  :fun discriminant_value: @_p.u16(0x2).bit_xor(65535)
+  :fun ref "discriminant_value="(new_value U16): @_p.set_u16(0x2, new_value.bit_xor(65535))
+
+  :fun is_slot: @_p.check_union(0x8, 0)
+  :fun ref slot!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Field.AS_slot.Builder.from_pointer(@_p)
+
+  :fun is_group: @_p.check_union(0x8, 1)
+  :fun ref group!: @_p.assert_union!(0x8, 1), CapnProto.Meta.Field.AS_group.Builder.from_pointer(@_p)
+
+  :fun ref ordinal: CapnProto.Meta.Field.AS_ordinal.Builder.from_pointer(@_p)
+
+:struct CapnProto.Meta.Field.AS_slot.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun offset: @_p.u32(0x4)
+  :fun ref "offset="(new_value U32): @_p.set_u32(0x4, new_value)
+
+  :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(2))
+
+  :fun ref default_value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(3))
+
+  :fun had_explicit_default: @_p.bool(0x10, 0b00000001)
+  :fun ref "had_explicit_default="(new_value Bool): @_p.set_bool(0x10, 0b00000001, new_value)
+
+:struct CapnProto.Meta.Field.AS_group.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun type_id: @_p.u64(0x10)
+  :fun ref "type_id="(new_value U64): @_p.set_u64(0x10, new_value)
+
+:struct CapnProto.Meta.Field.AS_ordinal.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun is_implicit: @_p.check_union(0xa, 0)
+  :fun implicit!: @_p.assert_union!(0xa, 0), None
+
+  :fun is_explicit: @_p.check_union(0xa, 1)
+  :fun explicit!: @_p.assert_union!(0xa, 1), @_p.u16(0xc)
+
+:struct CapnProto.Meta.Enumerant.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun ref name: @_p.text(0)
+
+  :fun code_order: @_p.u16(0x0)
+  :fun ref "code_order="(new_value U16): @_p.set_u16(0x0, new_value)
+
+  :fun ref annotations: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).new(@_p.list(1))
+
+:struct CapnProto.Meta.Superclass.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun id: @_p.u64(0x0)
+  :fun ref "id="(new_value U64): @_p.set_u64(0x0, new_value)
+
+  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0))
+
+:struct CapnProto.Meta.Method.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun ref name: @_p.text(0)
+
+  :fun code_order: @_p.u16(0x0)
+  :fun ref "code_order="(new_value U16): @_p.set_u16(0x0, new_value)
+
+  :fun param_struct_type: @_p.u64(0x8)
+  :fun ref "param_struct_type="(new_value U64): @_p.set_u64(0x8, new_value)
+
+  :fun result_struct_type: @_p.u64(0x10)
+  :fun ref "result_struct_type="(new_value U64): @_p.set_u64(0x10, new_value)
+
+  :fun ref annotations: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).new(@_p.list(1))
+
+  :fun ref param_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(2))
+
+  :fun ref result_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(3))
+
+  :fun ref implicit_parameters: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).new(@_p.list(4))
+
+:struct CapnProto.Meta.Type.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun is_void: @_p.check_union(0x0, 0)
+  :fun void!: @_p.assert_union!(0x0, 0), None
+
+  :fun is_bool: @_p.check_union(0x0, 1)
+  :fun bool!: @_p.assert_union!(0x0, 1), None
+
+  :fun is_int8: @_p.check_union(0x0, 2)
+  :fun int8!: @_p.assert_union!(0x0, 2), None
+
+  :fun is_int16: @_p.check_union(0x0, 3)
+  :fun int16!: @_p.assert_union!(0x0, 3), None
+
+  :fun is_int32: @_p.check_union(0x0, 4)
+  :fun int32!: @_p.assert_union!(0x0, 4), None
+
+  :fun is_int64: @_p.check_union(0x0, 5)
+  :fun int64!: @_p.assert_union!(0x0, 5), None
+
+  :fun is_uint8: @_p.check_union(0x0, 6)
+  :fun uint8!: @_p.assert_union!(0x0, 6), None
+
+  :fun is_uint16: @_p.check_union(0x0, 7)
+  :fun uint16!: @_p.assert_union!(0x0, 7), None
+
+  :fun is_uint32: @_p.check_union(0x0, 8)
+  :fun uint32!: @_p.assert_union!(0x0, 8), None
+
+  :fun is_uint64: @_p.check_union(0x0, 9)
+  :fun uint64!: @_p.assert_union!(0x0, 9), None
+
+  :fun is_float32: @_p.check_union(0x0, 10)
+  :fun float32!: @_p.assert_union!(0x0, 10), None
+
+  :fun is_float64: @_p.check_union(0x0, 11)
+  :fun float64!: @_p.assert_union!(0x0, 11), None
+
+  :fun is_text: @_p.check_union(0x0, 12)
+  :fun text!: @_p.assert_union!(0x0, 12), None
+
+  :fun is_data: @_p.check_union(0x0, 13)
+  :fun data!: @_p.assert_union!(0x0, 13), None
+
+  :fun is_list: @_p.check_union(0x0, 14)
+  :fun ref list!: @_p.assert_union!(0x0, 14), CapnProto.Meta.Type.AS_list.Builder.from_pointer(@_p)
+
+  :fun is_enum: @_p.check_union(0x0, 15)
+  :fun ref enum!: @_p.assert_union!(0x0, 15), CapnProto.Meta.Type.AS_enum.Builder.from_pointer(@_p)
+
+  :fun is_struct: @_p.check_union(0x0, 16)
+  :fun ref struct!: @_p.assert_union!(0x0, 16), CapnProto.Meta.Type.AS_struct.Builder.from_pointer(@_p)
+
+  :fun is_interface: @_p.check_union(0x0, 17)
+  :fun ref interface!: @_p.assert_union!(0x0, 17), CapnProto.Meta.Type.AS_interface.Builder.from_pointer(@_p)
+
+  :fun is_any_pointer: @_p.check_union(0x0, 18)
+  :fun ref any_pointer!: @_p.assert_union!(0x0, 18), CapnProto.Meta.Type.AS_anyPointer.Builder.from_pointer(@_p)
+
+:struct CapnProto.Meta.Type.AS_list.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun ref element_type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(0))
+
+:struct CapnProto.Meta.Type.AS_enum.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun type_id: @_p.u64(0x8)
+  :fun ref "type_id="(new_value U64): @_p.set_u64(0x8, new_value)
+
+  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0))
+
+:struct CapnProto.Meta.Type.AS_struct.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun type_id: @_p.u64(0x8)
+  :fun ref "type_id="(new_value U64): @_p.set_u64(0x8, new_value)
+
+  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0))
+
+:struct CapnProto.Meta.Type.AS_interface.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun type_id: @_p.u64(0x8)
+  :fun ref "type_id="(new_value U64): @_p.set_u64(0x8, new_value)
+
+  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0))
+
+:struct CapnProto.Meta.Type.AS_anyPointer.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun is_unconstrained: @_p.check_union(0x8, 0)
+  :fun ref unconstrained!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained.Builder.from_pointer(@_p)
+
+  :fun is_parameter: @_p.check_union(0x8, 1)
+  :fun ref parameter!: @_p.assert_union!(0x8, 1), CapnProto.Meta.Type.AS_anyPointer.AS_parameter.Builder.from_pointer(@_p)
+
+  :fun is_implicit_method_parameter: @_p.check_union(0x8, 2)
+  :fun ref implicit_method_parameter!: @_p.assert_union!(0x8, 2), CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter.Builder.from_pointer(@_p)
+
+:struct CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun is_any_kind: @_p.check_union(0xa, 0)
+  :fun any_kind!: @_p.assert_union!(0xa, 0), None
+
+  :fun is_struct: @_p.check_union(0xa, 1)
+  :fun struct!: @_p.assert_union!(0xa, 1), None
+
+  :fun is_list: @_p.check_union(0xa, 2)
+  :fun list!: @_p.assert_union!(0xa, 2), None
+
+  :fun is_capability: @_p.check_union(0xa, 3)
+  :fun capability!: @_p.assert_union!(0xa, 3), None
+
+:struct CapnProto.Meta.Type.AS_anyPointer.AS_parameter.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun scope_id: @_p.u64(0x10)
+  :fun ref "scope_id="(new_value U64): @_p.set_u64(0x10, new_value)
+
+  :fun parameter_index: @_p.u16(0xa)
+  :fun ref "parameter_index="(new_value U16): @_p.set_u16(0xa, new_value)
+
+:struct CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun parameter_index: @_p.u16(0xa)
+  :fun ref "parameter_index="(new_value U16): @_p.set_u16(0xa, new_value)
+
+:struct CapnProto.Meta.Brand.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun ref scopes: CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).new(@_p.list(0))
+
+:struct CapnProto.Meta.Brand.Scope.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun scope_id: @_p.u64(0x0)
+  :fun ref "scope_id="(new_value U64): @_p.set_u64(0x0, new_value)
+
+  :fun is_bind: @_p.check_union(0x8, 0)
+  :fun ref bind!: @_p.assert_union!(0x8, 0), CapnProto.List.Builder(CapnProto.Meta.Brand.Binding.Builder).new(@_p.list(0))
+
+  :fun is_inherit: @_p.check_union(0x8, 1)
+  :fun inherit!: @_p.assert_union!(0x8, 1), None
+
+:struct CapnProto.Meta.Brand.Binding.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun is_unbound: @_p.check_union(0x0, 0)
+  :fun unbound!: @_p.assert_union!(0x0, 0), None
+
+  :fun is_type: @_p.check_union(0x0, 1)
+  :fun ref type!: @_p.assert_union!(0x0, 1), CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(0))
+
+:struct CapnProto.Meta.Value.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun is_void: @_p.check_union(0x0, 0)
+  :fun void!: @_p.assert_union!(0x0, 0), None
+
+  :fun is_bool: @_p.check_union(0x0, 1)
+  :fun bool!: @_p.assert_union!(0x0, 1), @_p.bool(0x2, 0b00000001)
+
+  :fun is_int8: @_p.check_union(0x0, 2)
+  :fun int8!: @_p.assert_union!(0x0, 2), @_p.i8(0x2)
+
+  :fun is_int16: @_p.check_union(0x0, 3)
+  :fun int16!: @_p.assert_union!(0x0, 3), @_p.i16(0x2)
+
+  :fun is_int32: @_p.check_union(0x0, 4)
+  :fun int32!: @_p.assert_union!(0x0, 4), @_p.i32(0x4)
+
+  :fun is_int64: @_p.check_union(0x0, 5)
+  :fun int64!: @_p.assert_union!(0x0, 5), @_p.i64(0x8)
+
+  :fun is_uint8: @_p.check_union(0x0, 6)
+  :fun uint8!: @_p.assert_union!(0x0, 6), @_p.u8(0x2)
+
+  :fun is_uint16: @_p.check_union(0x0, 7)
+  :fun uint16!: @_p.assert_union!(0x0, 7), @_p.u16(0x2)
+
+  :fun is_uint32: @_p.check_union(0x0, 8)
+  :fun uint32!: @_p.assert_union!(0x0, 8), @_p.u32(0x4)
+
+  :fun is_uint64: @_p.check_union(0x0, 9)
+  :fun uint64!: @_p.assert_union!(0x0, 9), @_p.u64(0x8)
+
+  :fun is_float32: @_p.check_union(0x0, 10)
+  :fun float32!: @_p.assert_union!(0x0, 10), @_p.f32(0x4)
+
+  :fun is_float64: @_p.check_union(0x0, 11)
+  :fun float64!: @_p.assert_union!(0x0, 11), @_p.f64(0x8)
+
+  :fun is_text: @_p.check_union(0x0, 12)
+  :fun ref text!: @_p.assert_union!(0x0, 12), @_p.text(0)
+
+  :fun is_data: @_p.check_union(0x0, 13)
+  :fun ref data!: @_p.assert_union!(0x0, 13), @_p.data(0)
+
+  :fun is_list: @_p.check_union(0x0, 14)
+  :fun ref list!: @_p.assert_union!(0x0, 14), None // UNHANDLED: anyPointer
+
+  :fun is_enum: @_p.check_union(0x0, 15)
+  :fun enum!: @_p.assert_union!(0x0, 15), @_p.u16(0x2)
+
+  :fun is_struct: @_p.check_union(0x0, 16)
+  :fun ref struct!: @_p.assert_union!(0x0, 16), None // UNHANDLED: anyPointer
+
+  :fun is_interface: @_p.check_union(0x0, 17)
+  :fun interface!: @_p.assert_union!(0x0, 17), None
+
+  :fun is_any_pointer: @_p.check_union(0x0, 18)
+  :fun ref any_pointer!: @_p.assert_union!(0x0, 18), None // UNHANDLED: anyPointer
+
+:struct CapnProto.Meta.Annotation.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun id: @_p.u64(0x0)
+  :fun ref "id="(new_value U64): @_p.set_u64(0x0, new_value)
+
+  :fun ref value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(0))
+
+  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(1))
+
+:struct CapnProto.Meta.CodeGeneratorRequest.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun ref nodes: CapnProto.List.Builder(CapnProto.Meta.Node.Builder).new(@_p.list(0))
+
+  :fun ref requested_files: CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).new(@_p.list(1))
+
+:struct CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun id: @_p.u64(0x0)
+  :fun ref "id="(new_value U64): @_p.set_u64(0x0, new_value)
+
+  :fun ref filename: @_p.text(0)
+
+  :fun ref imports: CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).new(@_p.list(1))
+
+:struct CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
   :new from_pointer(@_p)
 
   :fun id: @_p.u64(0x0)

--- a/src/CapnProto.Pointer.Struct.savi
+++ b/src/CapnProto.Pointer.Struct.savi
@@ -1,28 +1,14 @@
-:struct CapnProto.Pointer.Struct
-  :let _segments CapnProto.Segments
-  :let _segment CapnProto.Segment
-  :let _byte_offset U32
-  :let _data_word_count U16
-  :let _pointers_count U16
+:trait _ParsedStructPointer
   :new _new(
-    @_segments, @_segment, @_byte_offset, @_data_word_count, @_pointers_count
-  )
-
-  :new empty(@_segments, @_segment)
-    @_byte_offset = 0
-    @_data_word_count = 0
-    @_pointers_count = 0
-
-  :fun non from_segments!(
     segments CapnProto.Segments
-    start_offset USize = 0
-    segment_index USize = 0
+    segment CapnProto.Segment
+    byte_offset U32
+    data_word_count U16
+    pointers_count U16
   )
-    segment = segments._list[segment_index]!
-    value = segment._u64!(start_offset.u32)
-    @_parse!(segments, segment, start_offset.u32, value)
 
-  :fun non _parse!(segments, segment, current_offset U32, value U64)
+:module _ParseStructPointer(A _ParsedStructPointer)
+  :fun _parse!(segments, segment, current_offset U32, value U64)
     // Handle the case that this may be a far pointer, pointing to the pointer.
     override_byte_offset U32 = -1
     try (
@@ -72,7 +58,33 @@
     data_word_count = value.bit_shr(32).u16
     pointers_count = value.bit_shr(48).u16
 
-    @_new(segments, segment, byte_offset, data_word_count, pointers_count)
+    A._new(segments, segment, byte_offset, data_word_count, pointers_count)
+
+:struct CapnProto.Pointer.Struct
+  :let _segments CapnProto.Segments
+  :let _segment CapnProto.Segment
+  :let _byte_offset U32
+  :let _data_word_count U16
+  :let _pointers_count U16
+  :new _new(
+    @_segments, @_segment, @_byte_offset, @_data_word_count, @_pointers_count
+  )
+
+  :new empty(@_segments, @_segment)
+    @_byte_offset = 0
+    @_data_word_count = 0
+    @_pointers_count = 0
+
+  :fun non from_segments!(
+    segments CapnProto.Segments
+    start_offset USize = 0
+    segment_index USize = 0
+  )
+    segment = segments._list[segment_index]!
+    value = segment._u64!(start_offset.u32)
+    _ParseStructPointer(CapnProto.Pointer.Struct)._parse!(
+      segments, segment, start_offset.u32, value
+    )
 
   :fun _ptr_byte_offset!(n U16)
     error! unless (@_pointers_count > n)
@@ -108,6 +120,126 @@
 
   :fun ref _set_u64!(n U32, v U64)
     error! unless (@_data_word_count.u32 * 8 > n)
+    @_segment._set_u64!(@_byte_offset +! n, v)
+
+  :fun u8(n) U8: try (@_u8!(n) | 0)
+  :fun u16(n) U16: try (@_u16!(n) | 0)
+  :fun u32(n) U32: try (@_u32!(n) | 0)
+  :fun u64(n) U64: try (@_u64!(n) | 0)
+
+  :fun i8(n): @u8(n).i8
+  :fun i16(n): @u16(n).i16
+  :fun i32(n): @u32(n).i32
+  :fun i64(n): @u64(n).i64
+
+  :fun f32(n): @u32(n).f32
+  :fun f64(n): @u64(n).f64
+
+  :fun bool(n, bit_mask): @u8(n).bit_and(bit_mask) != 0
+
+  :fun assert_union!(n, value): error! if (@u16(n) != value)
+  :fun check_union(n, value): @u16(n) == value
+
+  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
+  :fun ref text(n): try (@_text!(n) | @_empty_text)
+  :fun ref _empty_text
+    CapnProto.Text.new(CapnProto.Pointer.U8List.empty(@_segments, @_segment))
+  :fun ref _text!(n)
+    byte_offset = @_ptr_byte_offset!(n)
+    CapnProto.Text._parse!(
+      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+    )
+
+  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
+  :fun ref data(n): try (@_data!(n) | @_empty_data)
+  :fun ref _empty_data
+    CapnProto.Data.new(CapnProto.Pointer.U8List.empty(@_segments, @_segment))
+  :fun ref _data!(n)
+    byte_offset = @_ptr_byte_offset!(n)
+    CapnProto.Data._parse!(
+      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+    )
+
+  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
+  :fun ref struct(n): try (@_struct!(n) | @_empty_struct)
+  :fun ref _empty_struct
+    CapnProto.Pointer.Struct.empty(@_segments, @_segment)
+  :fun ref _struct!(n):
+    byte_offset = @_ptr_byte_offset!(n)
+    _ParseStructPointer(CapnProto.Pointer.Struct)._parse!(
+      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+    )
+
+  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
+  :fun ref list(n): try (@_list!(n) | @_empty_list)
+  :fun ref _empty_list
+    CapnProto.Pointer.StructList.empty(@_segments, @_segment)
+  :fun ref _list!(n):
+    byte_offset = @_ptr_byte_offset!(n)
+    _ParseStructListPointer(CapnProto.Pointer.StructList)._parse!(
+      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+    )
+
+:struct CapnProto.Pointer.Struct.Builder
+  :let _segments CapnProto.Segments
+  :let _segment CapnProto.Segment
+  :let _byte_offset U32
+  :let _data_word_count U16
+  :let _pointers_count U16
+  :new _new(
+    @_segments, @_segment, @_byte_offset, @_data_word_count, @_pointers_count
+  )
+
+  :new empty(@_segments, @_segment)
+    @_byte_offset = 0
+    @_data_word_count = 0
+    @_pointers_count = 0
+
+  :fun non from_segments!(
+    segments CapnProto.Segments
+    start_offset USize = 0
+    segment_index USize = 0
+  )
+    segment = segments._list[segment_index]!
+    value = segment._u64!(start_offset.u32)
+    _ParseStructPointer(CapnProto.Pointer.Struct)._parse!(
+      segments, segment, start_offset.u32, value
+    )
+
+  :fun _ptr_byte_offset!(n U16)
+    // We don't need `@_pointers_count` bounds checking in Builder.
+    @_byte_offset +! (@_data_word_count +! n).u32 * 8
+
+  :fun _u8!(n U32)
+    // We don't need `@_data_word_count` bounds checking in Builder.
+    @_segment._u8!(@_byte_offset +! n)
+
+  :fun _u16!(n U32)
+    // We don't need `@_data_word_count` bounds checking in Builder.
+    @_segment._u16!(@_byte_offset +! n)
+
+  :fun _u32!(n U32)
+    // We don't need `@_data_word_count` bounds checking in Builder.
+    @_segment._u32!(@_byte_offset +! n)
+
+  :fun _u64!(n U32)
+    // We don't need `@_data_word_count` bounds checking in Builder.
+    @_segment._u64!(@_byte_offset +! n)
+
+  :fun ref _set_u8!(n U32, v U8)
+    // We don't need `@_data_word_count` bounds checking in Builder.
+    @_segment._set_u8!(@_byte_offset +! n, v)
+
+  :fun ref _set_u16!(n U32, v U16)
+    // We don't need `@_data_word_count` bounds checking in Builder.
+    @_segment._set_u16!(@_byte_offset +! n, v)
+
+  :fun ref _set_u32!(n U32, v U32)
+    // We don't need `@_data_word_count` bounds checking in Builder.
+    @_segment._set_u32!(@_byte_offset +! n, v)
+
+  :fun ref _set_u64!(n U32, v U64)
+    // We don't need `@_data_word_count` bounds checking in Builder.
     @_segment._set_u64!(@_byte_offset +! n, v)
 
   :fun u8(n) U8: try (@_u8!(n) | 0)
@@ -172,19 +304,19 @@
   // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
   :fun ref struct(n): try (@_struct!(n) | @_empty_struct)
   :fun ref _empty_struct
-    CapnProto.Pointer.Struct.empty(@_segments, @_segment)
+    CapnProto.Pointer.Struct.Builder.empty(@_segments, @_segment)
   :fun ref _struct!(n):
     byte_offset = @_ptr_byte_offset!(n)
-    CapnProto.Pointer.Struct._parse!(
+    _ParseStructPointer(CapnProto.Pointer.Struct.Builder)._parse!(
       @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
     )
 
   // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
   :fun ref list(n): try (@_list!(n) | @_empty_list)
   :fun ref _empty_list
-    CapnProto.Pointer.StructList.empty(@_segments, @_segment)
+    CapnProto.Pointer.StructList.Builder.empty(@_segments, @_segment)
   :fun ref _list!(n):
     byte_offset = @_ptr_byte_offset!(n)
-    CapnProto.Pointer.StructList._parse!(
+    _ParseStructListPointer(CapnProto.Pointer.StructList.Builder)._parse!(
       @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
     )

--- a/src/CapnProto.Pointer.StructList.savi
+++ b/src/CapnProto.Pointer.StructList.savi
@@ -1,34 +1,15 @@
-:struct CapnProto.Pointer.StructList
-  :let _segments CapnProto.Segments
-  :let _segment CapnProto.Segment
-  :let _byte_offset U32
-  :let _list_count U32
-  :let _data_word_count U16
-  :let _pointers_count U16
+:trait _ParsedStructListPointer
+  :new empty(segments CapnProto.Segments, segment CapnProto.Segment)
   :new _new(
-    @_segments
-    @_segment
-    @_byte_offset
-    @_list_count
-    @_data_word_count
-    @_pointers_count
-  )
-
-  :new empty(@_segments, @_segment)
-    @_byte_offset = 0
-    @_list_count = 0
-    @_data_word_count = 0
-    @_pointers_count = 0
-
-  :fun non from_segments!(
     segments CapnProto.Segments
-    start_offset USize = 0
-    segment_index USize = 0
+    segment CapnProto.Segment
+    byte_offset U32
+    list_count U32
+    data_word_count U16
+    pointers_count U16
   )
-    segment = segments._list[segment_index]!
-    value = segment._u64!(start_offset.u32)
-    @_parse!(segments, segment, start_offset.u32, value)
 
+:module _ParseStructListPointer(A _ParsedStructListPointer)
   :fun non _parse!(segments, segment, current_offset U32, value U64)
     // Handle the case that this may be a far pointer, pointing to the pointer.
     override_byte_offset U32 = -1
@@ -99,7 +80,7 @@
     // (D) indicate the number of 8-byte words of space needed for the list,
     // which is distinct from the number of elements in the list.
     word_count = upper_32.bit_shr(3).usize
-    return @empty(segments, segment) if (word_count == 0)
+    return A.empty(segments, segment) if (word_count == 0)
 
     // Read the tag pointer, which is similar to a struct pointer,
     // and describes the individual size of all structs in the list,
@@ -110,13 +91,46 @@
     data_word_count = tag_value.bit_shr(32).u16
     pointers_count = tag_value.bit_shr(48).u16
 
-    @_new(
+    A._new(
       segments
       segment
       byte_offset
       list_count
       data_word_count
       pointers_count
+    )
+
+:struct CapnProto.Pointer.StructList
+  :let _segments CapnProto.Segments
+  :let _segment CapnProto.Segment
+  :let _byte_offset U32
+  :let _list_count U32
+  :let _data_word_count U16
+  :let _pointers_count U16
+  :new _new(
+    @_segments
+    @_segment
+    @_byte_offset
+    @_list_count
+    @_data_word_count
+    @_pointers_count
+  )
+
+  :new empty(@_segments, @_segment)
+    @_byte_offset = 0
+    @_list_count = 0
+    @_data_word_count = 0
+    @_pointers_count = 0
+
+  :fun non from_segments!(
+    segments CapnProto.Segments
+    start_offset USize = 0
+    segment_index USize = 0
+  )
+    segment = segments._list[segment_index]!
+    value = segment._u64!(start_offset.u32)
+    _ParseStructListPointer(CapnProto.Pointer.StructList)._parse!(
+      segments, segment, start_offset.u32, value
     )
 
   // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
@@ -142,6 +156,65 @@
           +! (@_data_word_count.u32 +! @_pointers_count.u32) *! n *! 8
 
         yield CapnProto.Pointer.Struct._new(
+          @_segments, @_segment, byte_offset, @_data_word_count, @_pointers_count
+        )
+      )
+    )
+
+:struct CapnProto.Pointer.StructList.Builder
+  :let _segments CapnProto.Segments
+  :let _segment CapnProto.Segment
+  :let _byte_offset U32
+  :let _list_count U32
+  :let _data_word_count U16
+  :let _pointers_count U16
+  :new _new(
+    @_segments
+    @_segment
+    @_byte_offset
+    @_list_count
+    @_data_word_count
+    @_pointers_count
+  )
+
+  :new empty(@_segments, @_segment)
+    @_byte_offset = 0
+    @_list_count = 0
+    @_data_word_count = 0
+    @_pointers_count = 0
+
+  :fun non from_segments!(
+    segments CapnProto.Segments
+    start_offset USize = 0
+    segment_index USize = 0
+  )
+    segment = segments._list[segment_index]!
+    value = segment._u64!(start_offset.u32)
+    _ParseStructListPointer(CapnProto.Pointer.StructList.Builder)._parse!(
+      segments, segment, start_offset.u32, value
+    )
+
+  :fun ref "[]"(n U32)
+    try (
+      error! unless (n < @_list_count)
+
+      byte_offset = @_byte_offset
+        +! (@_data_word_count.u32 +! @_pointers_count.u32) *! n *! 8
+
+      CapnProto.Pointer.Struct.Builder._new(
+        @_segments, @_segment, byte_offset, @_data_word_count, @_pointers_count
+      )
+    |
+      CapnProto.Pointer.Struct.Builder.empty(@_segments, @_segment)
+    )
+
+  :fun ref each
+    @_list_count.times -> (n |
+      try (
+        byte_offset = @_byte_offset
+          +! (@_data_word_count.u32 +! @_pointers_count.u32) *! n *! 8
+
+        yield CapnProto.Pointer.Struct.Builder._new(
           @_segments, @_segment, byte_offset, @_data_word_count, @_pointers_count
         )
       )

--- a/src/capnpc-savi/_Gen.savi
+++ b/src/capnpc-savi/_Gen.savi
@@ -64,7 +64,7 @@
     || type.is_struct || type.is_interface || type.is_any_pointer
 
   // TODO: not `:fun ref`
-  :fun ref _type_name(t CapnProto.Meta.Type)
+  :fun ref _type_name(t CapnProto.Meta.Type, is_builder Bool)
     case (
     | t.is_void | "None"
     | t.is_bool | "Bool"
@@ -80,9 +80,19 @@
     | t.is_float64 | "F64"
     | t.is_text | "CapnProto.Text"
     | t.is_data | "CapnProto.Data"
-    | t.is_list | "CapnProto.List(\(try @_type_name(t.list!.element_type)))"
+    | t.is_list |
+      "CapnProto.List\(
+        if is_builder (".Builder" | "")
+      )(\(
+        try @_type_name(t.list!.element_type, is_builder)
+      ))"
     | t.is_enum | "\(try @_find_node_scoped_name(t.enum!.type_id))"
-    | t.is_struct | "\(try @_find_node_scoped_name(t.struct!.type_id))"
+    | t.is_struct |
+      "\(
+        try @_find_node_scoped_name(t.struct!.type_id)
+      )\(
+        if is_builder (".Builder" | "")
+      )"
     | t.is_interface | "INTERFACES_NOT_IMPLEMENTED"
     | t.is_any_pointer | "ANY_POINTER_NOT_IMPLEMENTED"
     | "NOT_IMPLEMENTED"
@@ -118,13 +128,16 @@
       // using the `capnp` compiler with the `--output=savi` option.
     >>>
     node.nested_nodes.each -> (nest_info |
-      try @_emit_type(@_find_node!(nest_info.id))
+      try @_emit_type(@_find_node!(nest_info.id), False)
+    )
+    node.nested_nodes.each -> (nest_info |
+      try @_emit_type(@_find_node!(nest_info.id), True)
     )
 
-  :fun ref _emit_type(node CapnProto.Meta.Node)
+  :fun ref _emit_type(node CapnProto.Meta.Node, is_builder Bool)
     case (
-    | node.is_enum | @_emit_enum(node)
-    | node.is_struct | @_emit_struct(node)
+    | node.is_enum | if is_builder.is_false @_emit_enum(node)
+    | node.is_struct | @_emit_struct(node, is_builder)
     | @_out << "\n\n// UNHANDLED: \(node.display_name)"
     )
 
@@ -149,9 +162,11 @@
     @_out << "\n      \(@_node_scoped_name(node)).\(zero_name)"
     @_out << "\n    )"
 
-  :fun ref _emit_struct(node CapnProto.Meta.Node)
+  :fun ref _emit_struct(node CapnProto.Meta.Node, is_builder Bool)
     @_out << "\n\n:struct \(@_node_scoped_name(node))"
+    if is_builder (@_out << ".Builder")
     @_out << "\n  :let _p CapnProto.Pointer.Struct"
+    if is_builder (@_out << ".Builder")
     @_out << "\n  :new from_pointer(@_p)"
 
     // Emit constant values.
@@ -161,7 +176,7 @@
         @_out << "\n\n  :const \(
           _TextCase.Snake[nest_info.name]
         ) \(
-          @_type_name(const.type)
+          @_type_name(const.type, is_builder)
         ): \(
           @_show_value(const.value)
         )"
@@ -173,13 +188,15 @@
     fields.each -> (field |
       @_out << "\n"
       try @_emit_field_check_union_method!(node, field)
-      @_emit_field_getter(node, field)
-      try @_emit_field_setter!(node, field)
+      @_emit_field_getter(node, field, is_builder)
+      if is_builder (
+        try @_emit_field_setter!(node, field)
+      )
     )
 
     // Emit other type definitions that act as groups for this struct.
     fields.each -> (field |
-      try @_emit_struct(@_find_node!(field.group!.type_id))
+      try @_emit_struct(@_find_node!(field.group!.type_id), is_builder)
     )
 
     // Emit other type definitions that are nested within this struct.
@@ -187,13 +204,14 @@
       try (
         nested = @_find_node!(nest_info.id)
         next if nested.is_const
-        @_emit_type(nested)
+        @_emit_type(nested, is_builder)
       )
     )
 
   :fun ref _emit_field_getter(
     node CapnProto.Meta.Node
     field CapnProto.Meta.Field
+    is_builder Bool
   )
     is_union = field.discriminant_value != field.no_discriminant
     needs_ref = try (@_is_pointer_type(field.slot!.type) | True)
@@ -206,7 +224,7 @@
       try @_emit_field_check_union!(node, field, True)
       @_out << ", "
     )
-    @_emit_field_get_expr(field)
+    @_emit_field_get_expr(field, is_builder)
 
   :fun ref _emit_field_setter!(
     node CapnProto.Meta.Node
@@ -222,7 +240,7 @@
     @_out << "\n  :fun ref \"\(
       _TextCase.Snake[field.name]
     )=\"(new_value \(
-      @_type_name(slot.type)
+      @_type_name(slot.type, False)
     )): "
     @_emit_field_set_expr(field, "new_value")
 
@@ -252,11 +270,15 @@
       field.discriminant_value
     ))"
 
-  :fun ref _emit_field_get_expr(field CapnProto.Meta.Field)
+  :fun ref _emit_field_get_expr(field CapnProto.Meta.Field, is_builder Bool)
     // First, handle the case where the field is a group instead of a slot.
     try (
       type_id = field.group!.type_id
-      @_out << "\(@_find_node_scoped_name(type_id)).from_pointer(@_p)"
+      @_out << "\(
+        @_find_node_scoped_name(type_id)
+      )\(
+        if is_builder (".Builder" | "")
+      ).from_pointer(@_p)"
       return
     )
 
@@ -368,9 +390,9 @@
       )
     | type.is_list |
       // TODO: handle default list values
-      @_out << "\(@_type_name(type)).new(@_p.list(\(offset)))"
+      @_out << "\(@_type_name(type, is_builder)).new(@_p.list(\(offset)))"
     | type.is_enum |
-      @_out << "\(@_type_name(type))._new("
+      @_out << "\(@_type_name(type, is_builder))._new("
       @_out << "@_p.u16(\((offset * 2).format.hex.without_leading_zeros))"
       try (
         if (slot.default_value.uint16! != 0) (
@@ -380,7 +402,7 @@
       @_out << ")"
     | type.is_struct |
       // TODO: handle default list values
-      @_out << "\(@_type_name(type)).from_pointer(@_p.struct(\(offset)))"
+      @_out << "\(@_type_name(type, is_builder)).from_pointer(@_p.struct(\(offset)))"
     | type.is_interface |
       @_out << "None // UNHANDLED: interface" // TODO: handle interfaces
     | type.is_any_pointer |


### PR DESCRIPTION
A Builder is guaranteed to be full-sized (all trailing zero bytes present), whereas a read-only struct view may have some trailing zero bytes missing, or may even be a totally missing/empty struct. We can't get rid of that requirement because canonical Capn Proto data removes trailing bytes and messages from older protocol versions may be missing trailing bytes for data that didn't exist yet at that time in the protocol.