### PR TITLE
Fix `CapnProto.List.[]!` to be partial.

### DIFF
--- a/spec/CapnProto.Pointer.StructList.Spec.savi
+++ b/spec/CapnProto.Pointer.StructList.Spec.savi
@@ -45,27 +45,25 @@
       Lonely D\
     ")
 
-    assert: p[0].u64(0x0) == 0x1111111111111111
-    assert: p[0].u64(0x8) == 0x2222222222222222
-    assert: p[0].u64(0x10) == 0 // outside the data region
-    assert: "\(p[0].text(0))" == "Hello A"
-    assert: "\(p[0].text(1))" == "" // outside the pointers region
+    assert: p[0]!.u64(0x0) == 0x1111111111111111
+    assert: p[0]!.u64(0x8) == 0x2222222222222222
+    assert: p[0]!.u64(0x10) == 0 // outside the data region
+    assert: "\(p[0]!.text(0))" == "Hello A"
+    assert: "\(p[0]!.text(1))" == "" // outside the pointers region
 
-    assert: p[1].u64(0x0) == 0x3333333333333333
-    assert: p[1].u64(0x8) == 0x4444444444444444
-    assert: p[1].u64(0x10) == 0 // outside the data region
-    assert: "\(p[1].text(0))" == "Hello B"
-    assert: "\(p[1].text(1))" == "" // outside the pointers region
+    assert: p[1]!.u64(0x0) == 0x3333333333333333
+    assert: p[1]!.u64(0x8) == 0x4444444444444444
+    assert: p[1]!.u64(0x10) == 0 // outside the data region
+    assert: "\(p[1]!.text(0))" == "Hello B"
+    assert: "\(p[1]!.text(1))" == "" // outside the pointers region
 
-    assert: p[2].u64(0x0) == 0x5555555555555555
-    assert: p[2].u64(0x8) == 0x6666666666666666
-    assert: p[2].u64(0x10) == 0 // outside the data region
-    assert: "\(p[2].text(0))" == "Hello C"
-    assert: "\(p[2].text(1))" == "" // outside the pointers region
+    assert: p[2]!.u64(0x0) == 0x5555555555555555
+    assert: p[2]!.u64(0x8) == 0x6666666666666666
+    assert: p[2]!.u64(0x10) == 0 // outside the data region
+    assert: "\(p[2]!.text(0))" == "Hello C"
+    assert: "\(p[2]!.text(1))" == "" // outside the pointers region
 
-    assert: p[3].u64(0x0) == 0 // outside the list region
-    assert: p[3].u64(0x8) == 0 // outside the list region
-    assert: "\(p[3].text(0))" == "" // outside the list region
+    assert error: p[3]! // outside the list region
 
     first_words Array(U64) = []
     p.each -> (struct | first_words << struct.u64(0x0))
@@ -94,12 +92,12 @@
       \xde\xad\xbe\xef\xde\xad\xbe\xef\
     "])
 
-    assert: p[0].u64(0x0) == 0x1111111111111111
-    assert: p[0].u64(0x8) == 0x2222222222222222
-    assert: p[0].u64(0x10) == 0 // outside the data region
-    assert: p[1].u64(0x0) == 0x3333333333333333
-    assert: p[1].u64(0x8) == 0x4444444444444444
-    assert: p[1].u64(0x10) == 0 // outside the data region
+    assert: p[0]!.u64(0x0) == 0x1111111111111111
+    assert: p[0]!.u64(0x8) == 0x2222222222222222
+    assert: p[0]!.u64(0x10) == 0 // outside the data region
+    assert: p[1]!.u64(0x0) == 0x3333333333333333
+    assert: p[1]!.u64(0x8) == 0x4444444444444444
+    assert: p[1]!.u64(0x10) == 0 // outside the data region
 
   :it "can point to a struct list region via a double-far pointer"
     p = @from_segments([b"\
@@ -125,9 +123,9 @@
       \xde\xad\xbe\xef\xde\xad\xbe\xef\
     "])
 
-    assert: p[0].u64(0x0) == 0x1111111111111111
-    assert: p[0].u64(0x8) == 0x2222222222222222
-    assert: p[0].u64(0x10) == 0 // outside the data region
-    assert: p[1].u64(0x0) == 0x3333333333333333
-    assert: p[1].u64(0x8) == 0x4444444444444444
-    assert: p[1].u64(0x10) == 0 // outside the data region
+    assert: p[0]!.u64(0x0) == 0x1111111111111111
+    assert: p[0]!.u64(0x8) == 0x2222222222222222
+    assert: p[0]!.u64(0x10) == 0 // outside the data region
+    assert: p[1]!.u64(0x0) == 0x3333333333333333
+    assert: p[1]!.u64(0x8) == 0x4444444444444444
+    assert: p[1]!.u64(0x10) == 0 // outside the data region

--- a/src/CapnProto.List.savi
+++ b/src/CapnProto.List.savi
@@ -6,7 +6,7 @@
   :new from_pointer(@_p)
 
   // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
-  :fun ref "[]"(n): A.from_pointer(@_p[n])
+  :fun ref "[]!"(n): A.from_pointer(@_p[n]!)
 
   // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
   :fun ref each
@@ -21,7 +21,7 @@
   :new from_pointer(@_p)
 
   // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
-  :fun ref "[]"(n): A.from_pointer(@_p[n])
+  :fun ref "[]!"(n): A.from_pointer(@_p[n]!)
 
   // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
   :fun ref each

--- a/src/CapnProto.Pointer.StructList.savi
+++ b/src/CapnProto.Pointer.StructList.savi
@@ -136,17 +136,13 @@
     )
 
   // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
-  :fun ref "[]"(n U32)
-    try (
-      error! unless (n < @_list_count)
+  :fun ref "[]!"(n U32)
+    error! unless (n < @_list_count)
 
-      byte_offset = @_byte_offset +! @_element_byte_size *! n
+    byte_offset = @_byte_offset +! @_element_byte_size *! n
 
-      CapnProto.Pointer.Struct._new(
-        @_segments, @_segment, byte_offset, @_data_word_count, @_pointers_count
-      )
-    |
-      CapnProto.Pointer.Struct.empty(@_segments, @_segment)
+    CapnProto.Pointer.Struct._new(
+      @_segments, @_segment, byte_offset, @_data_word_count, @_pointers_count
     )
 
   // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
@@ -217,18 +213,14 @@
       segments, segment, start_offset.u32, value
     )
 
-  :fun ref "[]"(n U32)
-    try (
-      error! unless (n < @_list_count)
+  :fun ref "[]!"(n U32)
+    error! unless (n < @_list_count)
 
-      byte_offset = @_byte_offset
-        +! (@_data_word_count.u32 +! @_pointers_count.u32) *! n *! 8
+    byte_offset = @_byte_offset
+      +! (@_data_word_count.u32 +! @_pointers_count.u32) *! n *! 8
 
-      CapnProto.Pointer.Struct.Builder._new(
-        @_segments, @_segment, byte_offset, @_data_word_count, @_pointers_count
-      )
-    |
-      CapnProto.Pointer.Struct.Builder.empty(@_segments, @_segment)
+    CapnProto.Pointer.Struct.Builder._new(
+      @_segments, @_segment, byte_offset, @_data_word_count, @_pointers_count
     )
 
   :fun ref each


### PR DESCRIPTION
Prior to this commit, accessing by index in a `CapnProto.List` would return an empty struct instance pointing to nothing.

This was technically safe (the empty struct couldn't be used to violate any other data, and was basically ineffective at doing anything), but it was confusing and thus harmful. Particularly in the `Builder` context, it was bad for someone to think they had gotten a real struct instance to start building data into, while it was in reality silently discarding all their writes and doing nothing.

Now, this method will correctly raise an `error!` in that situation instead, letting the caller know of the issue.