### PR TITLE
Add `init_` methods for list builders.

### DIFF
--- a/spec/CapnProto.Message.Builder.Spec.savi
+++ b/spec/CapnProto.Message.Builder.Spec.savi
@@ -20,11 +20,28 @@
   :fun ref "some_u8="(new_value): @_p.set_u8(0x1e, new_value, 0)
   :fun ref "some_i8="(new_value): @_p.set_i8(0x1f, new_value, 0)
 
-  :const capn_proto_pointer_count U16: 2
+  :const capn_proto_pointer_count U16: 3
   :fun ref some_text: @_p.text(0)
   :fun ref some_data: @_p.data(1)
   :fun ref "some_text="(new_value): @_p.set_text(0, new_value, "")
   :fun ref "some_data="(new_value): @_p.set_data(1, new_value, b"")
+
+  :fun ref children: CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.list(2))
+  :fun ref init_children(new_count): CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.init_list(2, 2, 1, new_count))
+
+:struct _ExampleChildBuilder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :const capn_proto_data_word_count U16: 2
+  :fun a: @_p.u64(0x0)
+  :fun b: @_p.u64(0x8)
+  :fun ref "a="(new_value): @_p.set_u64(0x0, new_value, 0)
+  :fun ref "b="(new_value): @_p.set_u64(0x8, new_value, 0)
+
+  :const capn_proto_pointer_count U16: 1
+  :fun ref name: @_p.text(0)
+  :fun ref "name="(new_value): @_p.set_text(0, new_value, "")
 
 :class CapnProto.Message.Builder.Spec
   :is Spec
@@ -57,3 +74,39 @@
     assert: "\(root.some_data)" == "This is some example data"
     root.some_data              = b""
     assert: "\(root.some_data)" == ""
+
+  :it "reads from and writes to fields of the list children structs"
+    message = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
+    root = message.root
+
+    assert: root.children.size == 0
+    assert error: root.children[0]!
+
+    assert: root.init_children(3).size == 3
+    assert: root.children[0]!.a == 0
+    assert: root.children[0]!.b == 0
+    assert: "\(root.children[0]!.name)" == ""
+    assert: root.children[2]!.a == 0
+    assert: root.children[2]!.b == 0
+    assert: "\(root.children[2]!.name)" == ""
+    assert error: root.children[3]!
+
+    children = root.children
+    assert: (children[0]!.a = 11, children[0]!.a == 11)
+    assert: (children[0]!.b = 22, children[0]!.b == 22)
+    assert: (children[0]!.name = "foo", "\(children[0]!.name)" == "foo")
+    assert: (children[1]!.a = 33, children[1]!.a == 33)
+    assert: (children[1]!.b = 44, children[1]!.b == 44)
+    assert: (children[1]!.name = "bar", "\(children[1]!.name)" == "bar")
+    assert: (children[2]!.a = 55, children[2]!.a == 55)
+    assert: (children[2]!.b = 66, children[2]!.b == 66)
+    assert: (children[2]!.name = "baz", "\(children[2]!.name)" == "baz")
+
+    assert: root.init_children(1000).size == 1000
+    assert: root.children[0]!.a == 0
+    assert: root.children[0]!.b == 0
+    assert: "\(root.children[0]!.name)" == ""
+    assert: root.children[999]!.a == 0
+    assert: root.children[999]!.b == 0
+    assert: "\(root.children[999]!.name)" == ""
+    assert error: root.children[1000]!

--- a/spec/CapnProto.Pointer.Struct.Builder.Spec.savi
+++ b/spec/CapnProto.Pointer.Struct.Builder.Spec.savi
@@ -2,12 +2,12 @@
   :is Spec
   :const describes: "CapnProto.Pointer.Struct.Builder"
 
-  :fun init_with_size(data_word_count U16, pointers_count U16)
-    byte_size = (data_word_count + pointers_count).usize * 8
+  :fun init_with_size(data_word_count U16, pointer_count U16)
+    byte_size = (data_word_count + pointer_count).usize * 8
     segment = CapnProto.Segment.new(byte_size)
     segments = CapnProto.Segments.new([segment])
     CapnProto.Pointer.Struct.Builder._new(
-      segments, segment, 0, data_word_count, pointers_count
+      segments, segment, 0, data_word_count, pointer_count
     )
 
   :it "writes and reads numeric values in the data region"

--- a/src/CapnProto.List.savi
+++ b/src/CapnProto.List.savi
@@ -5,6 +5,8 @@
   :let _p CapnProto.Pointer.StructList
   :new from_pointer(@_p)
 
+  :fun size: @_p._list_count.usize
+
   // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
   :fun ref "[]!"(n): A.from_pointer(@_p[n]!)
 
@@ -19,6 +21,8 @@
 :struct CapnProto.List.Builder(A _FromStructPointerBuilder)
   :let _p CapnProto.Pointer.StructList.Builder
   :new from_pointer(@_p)
+
+  :fun size: @_p._list_count.usize
 
   // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
   :fun ref "[]!"(n): A.from_pointer(@_p[n]!)

--- a/src/CapnProto.Meta.capnp.savi
+++ b/src/CapnProto.Meta.capnp.savi
@@ -606,8 +606,10 @@
   :fun ref "scope_id="(new_value): @_p.set_u64(0x10, new_value, 0)
 
   :fun ref nested_nodes: CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).from_pointer(@_p.list(1))
+  :fun ref init_nested_nodes(new_count): CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).from_pointer(@_p.init_list(1, 1, 1, new_count))
 
   :fun ref annotations: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list(2))
+  :fun ref init_annotations(new_count): CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(2, 1, 2, new_count))
 
   :fun is_file: @_p.check_union(0xc, 0)
   :fun file!: @_p.assert_union!(0xc, 0), None
@@ -628,6 +630,7 @@
   :fun ref annotation!: @_p.assert_union!(0xc, 5), CapnProto.Meta.Node.AS_annotation.Builder.from_pointer(@_p)
 
   :fun ref parameters: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list(5))
+  :fun ref init_parameters(new_count): CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.init_list(5, 0, 1, new_count))
 
   :fun is_generic: @_p.bool(0x24, 0b00000001)
   :fun ref "is_generic="(new_value): @_p.set_bool(0x24, 0b00000001, new_value)
@@ -658,6 +661,7 @@
   :fun ref "discriminant_offset="(new_value): @_p.set_u32(0x20, new_value, 0)
 
   :fun ref fields: CapnProto.List.Builder(CapnProto.Meta.Field.Builder).from_pointer(@_p.list(3))
+  :fun ref init_fields(new_count): CapnProto.List.Builder(CapnProto.Meta.Field.Builder).from_pointer(@_p.init_list(3, 3, 4, new_count))
 
 :struct CapnProto.Meta.Node.AS_enum.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -667,6 +671,7 @@
   :const capn_proto_pointer_count U16: 6
 
   :fun ref enumerants: CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.list(3))
+  :fun ref init_enumerants(new_count): CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.init_list(3, 1, 2, new_count))
 
 :struct CapnProto.Meta.Node.AS_interface.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -676,8 +681,10 @@
   :const capn_proto_pointer_count U16: 6
 
   :fun ref methods: CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.list(3))
+  :fun ref init_methods(new_count): CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.init_list(3, 3, 5, new_count))
 
   :fun ref superclasses: CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.list(4))
+  :fun ref init_superclasses(new_count): CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.init_list(4, 1, 1, new_count))
 
 :struct CapnProto.Meta.Node.AS_const.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -774,6 +781,7 @@
   :fun ref "code_order="(new_value): @_p.set_u16(0x0, new_value, 0)
 
   :fun ref annotations: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list(1))
+  :fun ref init_annotations(new_count): CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
 
   :fun discriminant_value: @_p.u16(0x2).bit_xor(65535)
   :fun ref "discriminant_value="(new_value): @_p.set_u16(0x2, new_value, 65535)
@@ -840,6 +848,7 @@
   :fun ref "code_order="(new_value): @_p.set_u16(0x0, new_value, 0)
 
   :fun ref annotations: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list(1))
+  :fun ref init_annotations(new_count): CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
 
 :struct CapnProto.Meta.Superclass.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -873,12 +882,14 @@
   :fun ref "result_struct_type="(new_value): @_p.set_u64(0x10, new_value, 0)
 
   :fun ref annotations: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list(1))
+  :fun ref init_annotations(new_count): CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
 
   :fun ref param_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(2))
 
   :fun ref result_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(3))
 
   :fun ref implicit_parameters: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list(4))
+  :fun ref init_implicit_parameters(new_count): CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.init_list(4, 0, 1, new_count))
 
 :struct CapnProto.Meta.Type.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1055,6 +1066,7 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun ref scopes: CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.list(0))
+  :fun ref init_scopes(new_count): CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.init_list(0, 2, 1, new_count))
 
 :struct CapnProto.Meta.Brand.Scope.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1171,8 +1183,10 @@
   :const capn_proto_pointer_count U16: 2
 
   :fun ref nodes: CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.list(0))
+  :fun ref init_nodes(new_count): CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.init_list(0, 5, 6, new_count))
 
   :fun ref requested_files: CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.list(1))
+  :fun ref init_requested_files(new_count): CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
 
 :struct CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1188,6 +1202,7 @@
   :fun ref "filename="(new_value): @_p.set_text(0, new_value, "")
 
   :fun ref imports: CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).from_pointer(@_p.list(1))
+  :fun ref init_imports(new_count): CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).from_pointer(@_p.init_list(1, 1, 1, new_count))
 
 :struct CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder
   :let _p CapnProto.Pointer.Struct.Builder

--- a/src/CapnProto.Pointer.Struct.savi
+++ b/src/CapnProto.Pointer.Struct.savi
@@ -4,7 +4,7 @@
     segment CapnProto.Segment
     byte_offset U32
     data_word_count U16
-    pointers_count U16
+    pointer_count U16
   )
 
 :module _ParseStructPointer(A _ParsedStructPointer)
@@ -56,9 +56,9 @@
     // of the struct's data section and its pointers section, in 8-byte words.
     // These allow us to calculate the pointers section offset and end offset.
     data_word_count = value.bit_shr(32).u16
-    pointers_count = value.bit_shr(48).u16
+    pointer_count = value.bit_shr(48).u16
 
-    A._new(segments, segment, byte_offset, data_word_count, pointers_count)
+    A._new(segments, segment, byte_offset, data_word_count, pointer_count)
 
 :module _WriteStructPointer
   :fun _encode_with_zero_relative_offset(
@@ -75,22 +75,22 @@
     // C (16 bits) = Size of the struct's data section, in words.
     // D (16 bits) = Size of the struct's pointer section, in words.
     pointer._data_word_count.u64.bit_shl(32)           // C
-      .bit_or(pointer._pointers_count.u64.bit_shl(48)) // D (A and B are zero)
+      .bit_or(pointer._pointer_count.u64.bit_shl(48)) // D (A and B are zero)
 
 :struct CapnProto.Pointer.Struct
   :let _segments CapnProto.Segments
   :let _segment CapnProto.Segment
   :let _byte_offset U32
   :let _data_word_count U16
-  :let _pointers_count U16
+  :let _pointer_count U16
   :new _new(
-    @_segments, @_segment, @_byte_offset, @_data_word_count, @_pointers_count
+    @_segments, @_segment, @_byte_offset, @_data_word_count, @_pointer_count
   )
 
   :new empty(@_segments, @_segment)
     @_byte_offset = 0
     @_data_word_count = 0
-    @_pointers_count = 0
+    @_pointer_count = 0
 
   :fun non from_segments!(
     segments CapnProto.Segments
@@ -104,7 +104,7 @@
     )
 
   :fun _ptr_byte_offset!(n U16)
-    error! unless (@_pointers_count > n)
+    error! unless (@_pointer_count > n)
     @_byte_offset +! (@_data_word_count +! n).u32 * 8
 
   :fun _u8!(n U32)
@@ -204,15 +204,15 @@
   :let _segment CapnProto.Segment
   :let _byte_offset U32
   :let _data_word_count U16
-  :let _pointers_count U16
+  :let _pointer_count U16
   :new _new(
-    @_segments, @_segment, @_byte_offset, @_data_word_count, @_pointers_count
+    @_segments, @_segment, @_byte_offset, @_data_word_count, @_pointer_count
   )
 
   :new empty(@_segments, @_segment)
     @_byte_offset = 0
     @_data_word_count = 0
-    @_pointers_count = 0
+    @_pointer_count = 0
 
   :fun non from_segments!(
     segments CapnProto.Segments
@@ -226,7 +226,7 @@
     )
 
   :fun _ptr_byte_offset!(n U16)
-    error! unless (@_pointers_count > n)
+    error! unless (@_pointer_count > n)
     @_byte_offset +! (@_data_word_count +! n).u32 * 8
 
   :fun _u8!(n U32)
@@ -359,7 +359,7 @@
     // and we'll return an empty `CapnProto.Data` to signal this problem.
     byte_offset = try (@_ptr_byte_offset!(n) | return @_empty_data)
 
-    // If there's an existing text pointer, we can free it now.
+    // If there's an existing data pointer, we can free it now.
     try CapnProto.Data._parse!(
       @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
     )._p._free
@@ -401,3 +401,39 @@
     _ParseStructListPointer(CapnProto.Pointer.StructList.Builder)._parse!(
       @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
     )
+
+  :fun ref init_list(
+    n U16
+    data_word_count U16
+    pointer_count U16
+    new_list_count U32
+  ) CapnProto.Pointer.StructList.Builder
+    // We expect the byte offset to be within bounds - otherwise we can't do it,
+    // and we'll return an empty `CapnProto.Data` to signal this problem.
+    byte_offset = try (@_ptr_byte_offset!(n) | return @_empty_list)
+
+    // If there's an existing list pointer, we can free it now.
+    try _ParseStructListPointer(CapnProto.Pointer.StructList.Builder)._parse!(
+      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+    )._free
+
+    // If the requested count is empty, we won't allocate anything new.
+    // We'll just write zero bytes to that pointer's position and return.
+    if new_list_count.is_zero (
+      try @_segment._set_u64!(byte_offset, 0)
+      return @_empty_list
+    )
+
+    // Now we allocate the new one.
+    new_pointer = CapnProto.Pointer.StructList.Builder._allocate(
+      @_segments, @_segment
+      new_list_count, data_word_count, pointer_count
+    )
+
+    // We need to write the pointer to the buffer so it can be followed.
+    try @_segment._set_u64!(
+      byte_offset
+      _WriteStructListPointer._encode(byte_offset, new_pointer)
+    )
+
+    new_pointer

--- a/src/CapnProto.Pointer.StructList.savi
+++ b/src/CapnProto.Pointer.StructList.savi
@@ -6,11 +6,11 @@
     byte_offset U32
     list_count U32
     data_word_count U16
-    pointers_count U16
+    pointer_count U16
   )
 
 :module _ParseStructListPointer(A _ParsedStructListPointer)
-  :fun non _parse!(segments, segment, current_offset U32, value U64)
+  :fun non _parse!(segments, segment, current_offset U32, value U64) A
     // Handle the case that this may be a far pointer, pointing to the pointer.
     override_byte_offset U32 = -1
     try (
@@ -89,7 +89,7 @@
     error! unless (tag_value.u8.bit_and(0b11) == 0)
     list_count = tag_value.u32.bit_shr(2)
     data_word_count = tag_value.bit_shr(32).u16
-    pointers_count = tag_value.bit_shr(48).u16
+    pointer_count = tag_value.bit_shr(48).u16
 
     A._new(
       segments
@@ -97,8 +97,48 @@
       byte_offset
       list_count
       data_word_count
-      pointers_count
+      pointer_count
     )
+
+:module _WriteStructListPointer
+  :fun _encode(write_offset U32, pointer CapnProto.Pointer.StructList.Builder)
+    // lsb                       list pointer                        msb
+    // +-+-----------------------------+--+----------------------------+
+    // |A|             B               |C |             D              |
+    // +-+-----------------------------+--+----------------------------+
+
+    // A (2 bits) = 1, to indicate that this is a list pointer.
+    // B (30 bits) = Offset, in words, from the end of the pointer to the
+    //     start of the first element of the list.  Signed.
+    // C (3 bits) = Size of each element:
+    //     0 = 0 (e.g. List(Void))
+    //     1 = 1 bit
+    //     2 = 1 byte
+    //     3 = 2 bytes
+    //     4 = 4 bytes
+    //     5 = 8 bytes (non-pointer)
+    //     6 = 8 bytes (pointer)
+    //     7 = composite (see below)
+    // D (29 bits) = Size of the list:
+    //     when C <> 7: Number of elements in the list.
+    //     when C = 7: Number of words in the list, not counting the tag word
+    //     (see below).
+
+    // Note that for relative words, we subtract 2 instead of 1 because
+    // the tag word is an extra landing pad.
+    relative_words = (pointer._byte_offset / 8).i32 - (write_offset / 8).i32 - 2
+
+    per_struct_words = pointer._data_word_count.u32 + pointer._pointer_count.u32
+    total_list_words = per_struct_words.saturating_multiply(pointer._list_count)
+
+    total_list_words.at_most(0x1FFFFFFF).u64.bit_shl(35) // D
+      .bit_or(relative_words.u64.bit_shl(2))             // B
+      .bit_or(0x0000000700000001)                        // A and C
+
+  :fun _encode_tag(pointer CapnProto.Pointer.StructList.Builder)
+    pointer._list_count.at_most(0x3fffffff).u64.bit_shl(2) // B
+      .bit_or(pointer._data_word_count.u64.bit_shl(32))    // C
+      .bit_or(pointer._pointer_count.u64.bit_shl(48))      // D (A is zero)
 
 :struct CapnProto.Pointer.StructList
   :let _segments CapnProto.Segments
@@ -106,23 +146,23 @@
   :let _byte_offset U32
   :let _list_count U32
   :let _data_word_count U16
-  :let _pointers_count U16
+  :let _pointer_count U16
   :new _new(
     @_segments
     @_segment
     @_byte_offset
     @_list_count
     @_data_word_count
-    @_pointers_count
+    @_pointer_count
   )
 
   :new empty(@_segments, @_segment)
     @_byte_offset = 0
     @_list_count = 0
     @_data_word_count = 0
-    @_pointers_count = 0
+    @_pointer_count = 0
 
-  :fun _element_byte_size: (@_data_word_count.u32 + @_pointers_count.u32) * 8
+  :fun _element_byte_size: (@_data_word_count.u32 + @_pointer_count.u32) * 8
 
   :fun non from_segments!(
     segments CapnProto.Segments
@@ -142,7 +182,7 @@
     byte_offset = @_byte_offset +! @_element_byte_size *! n
 
     CapnProto.Pointer.Struct._new(
-      @_segments, @_segment, byte_offset, @_data_word_count, @_pointers_count
+      @_segments, @_segment, byte_offset, @_data_word_count, @_pointer_count
     )
 
   // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
@@ -152,7 +192,7 @@
         byte_offset = @_byte_offset +! @_element_byte_size *! n
 
         yield CapnProto.Pointer.Struct._new(
-          @_segments, @_segment, byte_offset, @_data_word_count, @_pointers_count
+          @_segments, @_segment, byte_offset, @_data_word_count, @_pointer_count
         )
       )
     )
@@ -163,23 +203,38 @@
   :let _byte_offset U32
   :let _list_count U32
   :let _data_word_count U16
-  :let _pointers_count U16
+  :let _pointer_count U16
   :new _new(
     @_segments
     @_segment
     @_byte_offset
     @_list_count
     @_data_word_count
-    @_pointers_count
+    @_pointer_count
   )
 
   :new empty(@_segments, @_segment)
     @_byte_offset = 0
     @_list_count = 0
     @_data_word_count = 0
-    @_pointers_count = 0
+    @_pointer_count = 0
 
-  :fun _element_byte_size: (@_data_word_count.u32 + @_pointers_count.u32) * 8
+  :fun _element_byte_size: (@_data_word_count.u32 + @_pointer_count.u32) * 8
+  :fun _total_byte_size
+    try (@_element_byte_size *! @_list_count | U32.max_value)
+
+  :fun ref _free: @_segment._free_pointer(@_byte_offset, @_total_byte_size), @
+
+  :new _allocate(
+    @_segments
+    @_segment
+    @_list_count
+    @_data_word_count
+    @_pointer_count
+  )
+    byte_offset = @_segment._allocate_pointer(@_total_byte_size + 8)
+    @_byte_offset = byte_offset + 8
+    try @_segment._set_u64!(byte_offset, _WriteStructListPointer._encode_tag(@))
 
   :fun ref _reallocate(new_count U32)
     try (
@@ -195,7 +250,7 @@
         new_byte_offset
         new_count
         @_data_word_count
-        @_pointers_count
+        @_pointer_count
       )
     |
       // If the new list size is out of bounds for U32, don't resize at all.
@@ -217,20 +272,20 @@
     error! unless (n < @_list_count)
 
     byte_offset = @_byte_offset
-      +! (@_data_word_count.u32 +! @_pointers_count.u32) *! n *! 8
+      +! (@_data_word_count.u32 +! @_pointer_count.u32) *! n *! 8
 
     CapnProto.Pointer.Struct.Builder._new(
-      @_segments, @_segment, byte_offset, @_data_word_count, @_pointers_count
+      @_segments, @_segment, byte_offset, @_data_word_count, @_pointer_count
     )
 
   :fun ref each
     @_list_count.times -> (n |
       try (
         byte_offset = @_byte_offset
-          +! (@_data_word_count.u32 +! @_pointers_count.u32) *! n *! 8
+          +! (@_data_word_count.u32 +! @_pointer_count.u32) *! n *! 8
 
         yield CapnProto.Pointer.Struct.Builder._new(
-          @_segments, @_segment, byte_offset, @_data_word_count, @_pointers_count
+          @_segments, @_segment, byte_offset, @_data_word_count, @_pointer_count
         )
       )
     )

--- a/src/CapnProto.Segment.savi
+++ b/src/CapnProto.Segment.savi
@@ -115,6 +115,9 @@
     final_hole_head.u32
 
   :fun ref _free_pointer(free_head U32, free_size U32)
+    // Round up the requested size to the nearest multiple of 8.
+    free_size = (free_size + 7).bit_and(-8)
+
     free_tail = free_head + free_size
 
     // First, fill the range with zeros to ensure it won't leak data.

--- a/src/capnpc-savi/_Gen.savi
+++ b/src/capnpc-savi/_Gen.savi
@@ -204,6 +204,9 @@
       if is_builder (
         try @_emit_field_setter!(node, field)
       )
+      if is_builder (
+        try @_emit_field_initter!(node, field)
+      )
     )
 
     // Emit other type definitions that act as groups for this struct.
@@ -254,6 +257,32 @@
 
     @_out << "\n  :fun ref \"\(_TextCase.Snake[field.name])=\"(new_value): "
     @_emit_field_set_expr(field, "new_value")
+
+  :fun ref _emit_field_initter!(
+    node CapnProto.Meta.Node
+    field CapnProto.Meta.Field
+  )
+    is_union = field.discriminant_value != field.no_discriminant
+    error! if is_union
+
+    slot = field.slot!
+    type = slot.type
+
+    // TODO: implement struct init, not just struct list init
+    struct_type = type.list!.element_type.struct!
+    struct = @_find_node!(struct_type.type_id).struct!
+
+    @_out << "\n  :fun ref init_\(
+      _TextCase.Snake[field.name]
+    )(new_count): \(
+      @_type_name(type, True)
+    ).from_pointer(@_p.init_list(\(
+      slot.offset
+    ), \(
+      struct.data_word_count
+    ), \(
+      struct.pointer_count
+    ), new_count))"
 
   :fun ref _emit_field_check_union_method!(
     node CapnProto.Meta.Node


### PR DESCRIPTION
This allows allocating a new list of a given size.