### PR TITLE
Refactor to make non-Builder structs `box` instead of `ref`.

### DIFF
--- a/spec/CapnProto.Pointer.Struct.Builder.Spec.savi
+++ b/spec/CapnProto.Pointer.Struct.Builder.Spec.savi
@@ -4,8 +4,8 @@
 
   :fun init_with_size(data_word_count U16, pointer_count U16)
     byte_size = (data_word_count + pointer_count).usize * 8
-    segment = CapnProto.Segment.new(byte_size)
-    segments = CapnProto.Segments.new([segment])
+    segments = CapnProto.Segments.new
+    segment = CapnProto.Segment.new(segments, byte_size)
     CapnProto.Pointer.Struct.Builder._new(
       segments, segment, 0, data_word_count, pointer_count
     )

--- a/spec/CapnProto.Pointer.Struct.Spec.savi
+++ b/spec/CapnProto.Pointer.Struct.Spec.savi
@@ -3,8 +3,8 @@
   :const describes: "CapnProto.Pointer.Struct"
 
   :fun from_segment(bytes Bytes, byte_offset USize = 0)
-    segment = CapnProto.Segment.new_from_bytes(bytes.clone)
-    segments = CapnProto.Segments.new([segment])
+    segments = CapnProto.Segments.new
+    segment = CapnProto.Segment.new_from_bytes(segments, bytes.clone)
     pointer = CapnProto.Pointer.Struct.empty(segments, segment)
     assert no_error: (
       pointer = CapnProto.Pointer.Struct.from_segments!(segments, byte_offset)
@@ -12,11 +12,11 @@
     pointer
 
   :fun from_segments(chunks Array(Bytes), byte_offset USize = 0)
-    segments = CapnProto.Segments.new([])
+    segments = CapnProto.Segments.new
     chunks.each -> (chunk |
-      segments._list.push(CapnProto.Segment.new_from_bytes(chunk.clone))
+      CapnProto.Segment.new_from_bytes(segments, chunk.clone)
     )
-    segment = try (segments._list[0]! | CapnProto.Segment.new_from_bytes(b"".clone))
+    segment = try (segments._list[0]! | CapnProto.Segment.new_from_bytes(segments, b"".clone))
     pointer = CapnProto.Pointer.Struct.empty(segments, segment)
     assert no_error: (
       pointer = CapnProto.Pointer.Struct.from_segments!(segments, byte_offset)

--- a/spec/CapnProto.Pointer.StructList.Spec.savi
+++ b/spec/CapnProto.Pointer.StructList.Spec.savi
@@ -3,8 +3,8 @@
   :const describes: "CapnProto.Pointer.StructList"
 
   :fun from_segment(bytes Bytes, byte_offset USize = 0)
-    segment = CapnProto.Segment.new_from_bytes(bytes.clone)
-    segments = CapnProto.Segments.new([segment])
+    segments = CapnProto.Segments.new
+    segment = CapnProto.Segment.new_from_bytes(segments, bytes.clone)
     pointer = CapnProto.Pointer.StructList.empty(segments, segment)
     assert no_error: (
       pointer = CapnProto.Pointer.StructList.from_segments!(segments, byte_offset)
@@ -12,11 +12,11 @@
     pointer
 
   :fun from_segments(chunks Array(Bytes), byte_offset USize = 0)
-    segments = CapnProto.Segments.new([])
+    segments = CapnProto.Segments.new
     chunks.each -> (chunk |
-      segments._list.push(CapnProto.Segment.new_from_bytes(chunk.clone))
+      CapnProto.Segment.new_from_bytes(segments, chunk.clone)
     )
-    segment = try (segments._list[0]! | CapnProto.Segment.new_from_bytes(b"".clone))
+    segment = try (segments._list[0]! | CapnProto.Segment.new_from_bytes(segments, b"".clone))
     pointer = CapnProto.Pointer.StructList.empty(segments, segment)
     assert no_error: (
       pointer = CapnProto.Pointer.StructList.from_segments!(segments, byte_offset)

--- a/spec/CapnProto.Pointer.U8List.Spec.savi
+++ b/spec/CapnProto.Pointer.U8List.Spec.savi
@@ -3,8 +3,8 @@
   :const describes: "CapnProto.Pointer.U8List"
 
   :fun from_segment(bytes Bytes, byte_offset USize = 0)
-    segment = CapnProto.Segment.new_from_bytes(bytes.clone)
-    segments = CapnProto.Segments.new([segment])
+    segments = CapnProto.Segments.new
+    segment = CapnProto.Segment.new_from_bytes(segments, bytes.clone)
     pointer = CapnProto.Pointer.U8List.empty(segments, segment)
     assert no_error: (
       pointer = CapnProto.Pointer.U8List.from_segments!(segments, byte_offset)
@@ -12,11 +12,11 @@
     pointer
 
   :fun from_segments(chunks Array(Bytes), byte_offset USize = 0)
-    segments = CapnProto.Segments.new([])
+    segments = CapnProto.Segments.new
     chunks.each -> (chunk |
-      segments._list.push(CapnProto.Segment.new_from_bytes(chunk.clone))
+      CapnProto.Segment.new_from_bytes(segments, chunk.clone)
     )
-    segment = try (segments._list[0]! | CapnProto.Segment.new_from_bytes(b"".clone))
+    segment = try (segments._list[0]! | CapnProto.Segment.new_from_bytes(segments, b"".clone))
     pointer = CapnProto.Pointer.U8List.empty(segments, segment)
     assert no_error: (
       pointer = CapnProto.Pointer.U8List.from_segments!(segments, byte_offset)

--- a/src/CapnProto.Data.savi
+++ b/src/CapnProto.Data.savi
@@ -1,16 +1,12 @@
 :struct CapnProto.Data
-  :let _p CapnProto.Pointer.U8List
+  :let _p CapnProto.Pointer.U8List'box
   :new from_pointer(@_p)
+  :new box read_from_pointer(p CapnProto.Pointer.U8List'box): @_p = p
 
-  :new _new(segments, segment, value Bytes)
+  :new _new(segments, segment CapnProto.Segment, value Bytes)
     byte_offset = segment._allocate_and_write_bytes(value)
-    @_p = CapnProto.Pointer.U8List._new(
+    @_p = CapnProto.Pointer.U8List._new_read(
       segments, segment, byte_offset, value.size.u32
-    )
-
-  :fun non _parse!(segments, segment, current_offset, value)
-    @from_pointer(
-      CapnProto.Pointer.U8List._parse!(segments, segment, current_offset, value)
     )
 
   :fun size: @_p._byte_count.usize

--- a/src/CapnProto.List.savi
+++ b/src/CapnProto.List.savi
@@ -1,19 +1,17 @@
-:trait _FromStructPointer
-  :new from_pointer(pointer CapnProto.Pointer.Struct)
+:trait box _FromStructPointer
+  :new box read_from_pointer(pointer CapnProto.Pointer.Struct)
 
-:struct CapnProto.List(A _FromStructPointer)
+:struct box CapnProto.List(A _FromStructPointer)
   :let _p CapnProto.Pointer.StructList
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :fun size: @_p._list_count.usize
 
-  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
-  :fun ref "[]!"(n): A.from_pointer(@_p[n]!)
+  :fun "[]!"(n): A.read_from_pointer(@_p[n]!)
 
-  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
-  :fun ref each
+  :fun each
     :yields A
-    @_p.each -> (p | yield A.from_pointer(p))
+    @_p.each -> (p | yield A.read_from_pointer(p))
 
 :trait _FromStructPointerBuilder
   :new from_pointer(pointer CapnProto.Pointer.Struct.Builder)
@@ -24,10 +22,8 @@
 
   :fun size: @_p._list_count.usize
 
-  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
   :fun ref "[]!"(n): A.from_pointer(@_p[n]!)
 
-  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
   :fun ref each
     :yields A
     @_p.each -> (p | yield A.from_pointer(p))

--- a/src/CapnProto.Message.savi
+++ b/src/CapnProto.Message.savi
@@ -14,8 +14,8 @@
     ) * 8 + 8
     initial_size = initial_size.at_least(alloc_byte_size)
 
-    segment = CapnProto.Segment.new(initial_size)
-    segments = CapnProto.Segments.new([segment])
+    segments = CapnProto.Segments.new
+    segment = CapnProto.Segment.new(segments, initial_size)
     pointer = CapnProto.Pointer.Struct.Builder._new(
       segments, segment, 8
       A.capn_proto_data_word_count, A.capn_proto_pointer_count

--- a/src/CapnProto.Meta.capnp.savi
+++ b/src/CapnProto.Meta.capnp.savi
@@ -2,50 +2,50 @@
 // NOTE: This file was auto-generated from a Cap'n Proto file
 // using the `capnp` compiler with the `--output=savi` option.
 
-:struct CapnProto.Meta.Node
+:struct box CapnProto.Meta.Node
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
 
   :fun id: @_p.u64(0x0)
 
-  :fun ref display_name: @_p.text(0)
+  :fun display_name: @_p.text(0)
 
   :fun display_name_prefix_length: @_p.u32(0x8)
 
   :fun scope_id: @_p.u64(0x10)
 
-  :fun ref nested_nodes: CapnProto.List(CapnProto.Meta.Node.NestedNode).from_pointer(@_p.list(1))
+  :fun nested_nodes: CapnProto.List(CapnProto.Meta.Node.NestedNode).read_from_pointer(@_p.list(1))
 
-  :fun ref annotations: CapnProto.List(CapnProto.Meta.Annotation).from_pointer(@_p.list(2))
+  :fun annotations: CapnProto.List(CapnProto.Meta.Annotation).read_from_pointer(@_p.list(2))
 
   :fun is_file: @_p.check_union(0xc, 0)
   :fun file!: @_p.assert_union!(0xc, 0), None
 
   :fun is_struct: @_p.check_union(0xc, 1)
-  :fun ref struct!: @_p.assert_union!(0xc, 1), CapnProto.Meta.Node.AS_struct.from_pointer(@_p)
+  :fun struct!: @_p.assert_union!(0xc, 1), CapnProto.Meta.Node.AS_struct.read_from_pointer(@_p)
 
   :fun is_enum: @_p.check_union(0xc, 2)
-  :fun ref enum!: @_p.assert_union!(0xc, 2), CapnProto.Meta.Node.AS_enum.from_pointer(@_p)
+  :fun enum!: @_p.assert_union!(0xc, 2), CapnProto.Meta.Node.AS_enum.read_from_pointer(@_p)
 
   :fun is_interface: @_p.check_union(0xc, 3)
-  :fun ref interface!: @_p.assert_union!(0xc, 3), CapnProto.Meta.Node.AS_interface.from_pointer(@_p)
+  :fun interface!: @_p.assert_union!(0xc, 3), CapnProto.Meta.Node.AS_interface.read_from_pointer(@_p)
 
   :fun is_const: @_p.check_union(0xc, 4)
-  :fun ref const!: @_p.assert_union!(0xc, 4), CapnProto.Meta.Node.AS_const.from_pointer(@_p)
+  :fun const!: @_p.assert_union!(0xc, 4), CapnProto.Meta.Node.AS_const.read_from_pointer(@_p)
 
   :fun is_annotation: @_p.check_union(0xc, 5)
-  :fun ref annotation!: @_p.assert_union!(0xc, 5), CapnProto.Meta.Node.AS_annotation.from_pointer(@_p)
+  :fun annotation!: @_p.assert_union!(0xc, 5), CapnProto.Meta.Node.AS_annotation.read_from_pointer(@_p)
 
-  :fun ref parameters: CapnProto.List(CapnProto.Meta.Node.Parameter).from_pointer(@_p.list(5))
+  :fun parameters: CapnProto.List(CapnProto.Meta.Node.Parameter).read_from_pointer(@_p.list(5))
 
   :fun is_generic: @_p.bool(0x24, 0b00000001)
 
-:struct CapnProto.Meta.Node.AS_struct
+:struct box CapnProto.Meta.Node.AS_struct
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
@@ -62,47 +62,47 @@
 
   :fun discriminant_offset: @_p.u32(0x20)
 
-  :fun ref fields: CapnProto.List(CapnProto.Meta.Field).from_pointer(@_p.list(3))
+  :fun fields: CapnProto.List(CapnProto.Meta.Field).read_from_pointer(@_p.list(3))
 
-:struct CapnProto.Meta.Node.AS_enum
+:struct box CapnProto.Meta.Node.AS_enum
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
 
-  :fun ref enumerants: CapnProto.List(CapnProto.Meta.Enumerant).from_pointer(@_p.list(3))
+  :fun enumerants: CapnProto.List(CapnProto.Meta.Enumerant).read_from_pointer(@_p.list(3))
 
-:struct CapnProto.Meta.Node.AS_interface
+:struct box CapnProto.Meta.Node.AS_interface
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
 
-  :fun ref methods: CapnProto.List(CapnProto.Meta.Method).from_pointer(@_p.list(3))
+  :fun methods: CapnProto.List(CapnProto.Meta.Method).read_from_pointer(@_p.list(3))
 
-  :fun ref superclasses: CapnProto.List(CapnProto.Meta.Superclass).from_pointer(@_p.list(4))
+  :fun superclasses: CapnProto.List(CapnProto.Meta.Superclass).read_from_pointer(@_p.list(4))
 
-:struct CapnProto.Meta.Node.AS_const
+:struct box CapnProto.Meta.Node.AS_const
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
 
-  :fun ref type: CapnProto.Meta.Type.from_pointer(@_p.struct(3))
+  :fun type: CapnProto.Meta.Type.read_from_pointer(@_p.struct(3))
 
-  :fun ref value: CapnProto.Meta.Value.from_pointer(@_p.struct(4))
+  :fun value: CapnProto.Meta.Value.read_from_pointer(@_p.struct(4))
 
-:struct CapnProto.Meta.Node.AS_annotation
+:struct box CapnProto.Meta.Node.AS_annotation
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
 
-  :fun ref type: CapnProto.Meta.Type.from_pointer(@_p.struct(3))
+  :fun type: CapnProto.Meta.Type.read_from_pointer(@_p.struct(3))
 
   :fun targets_file: @_p.bool(0xe, 0b00000001)
 
@@ -128,78 +128,78 @@
 
   :fun targets_annotation: @_p.bool(0xf, 0b00001000)
 
-:struct CapnProto.Meta.Node.Parameter
+:struct box CapnProto.Meta.Node.Parameter
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 1
 
-  :fun ref name: @_p.text(0)
+  :fun name: @_p.text(0)
 
-:struct CapnProto.Meta.Node.NestedNode
+:struct box CapnProto.Meta.Node.NestedNode
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
 
-  :fun ref name: @_p.text(0)
+  :fun name: @_p.text(0)
 
   :fun id: @_p.u64(0x0)
 
-:struct CapnProto.Meta.Field
+:struct box CapnProto.Meta.Field
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
 
   :const no_discriminant U16: 65535
 
-  :fun ref name: @_p.text(0)
+  :fun name: @_p.text(0)
 
   :fun code_order: @_p.u16(0x0)
 
-  :fun ref annotations: CapnProto.List(CapnProto.Meta.Annotation).from_pointer(@_p.list(1))
+  :fun annotations: CapnProto.List(CapnProto.Meta.Annotation).read_from_pointer(@_p.list(1))
 
   :fun discriminant_value: @_p.u16(0x2).bit_xor(65535)
 
   :fun is_slot: @_p.check_union(0x8, 0)
-  :fun ref slot!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Field.AS_slot.from_pointer(@_p)
+  :fun slot!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Field.AS_slot.read_from_pointer(@_p)
 
   :fun is_group: @_p.check_union(0x8, 1)
-  :fun ref group!: @_p.assert_union!(0x8, 1), CapnProto.Meta.Field.AS_group.from_pointer(@_p)
+  :fun group!: @_p.assert_union!(0x8, 1), CapnProto.Meta.Field.AS_group.read_from_pointer(@_p)
 
-  :fun ref ordinal: CapnProto.Meta.Field.AS_ordinal.from_pointer(@_p)
+  :fun ordinal: CapnProto.Meta.Field.AS_ordinal.read_from_pointer(@_p)
 
-:struct CapnProto.Meta.Field.AS_slot
+:struct box CapnProto.Meta.Field.AS_slot
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
 
   :fun offset: @_p.u32(0x4)
 
-  :fun ref type: CapnProto.Meta.Type.from_pointer(@_p.struct(2))
+  :fun type: CapnProto.Meta.Type.read_from_pointer(@_p.struct(2))
 
-  :fun ref default_value: CapnProto.Meta.Value.from_pointer(@_p.struct(3))
+  :fun default_value: CapnProto.Meta.Value.read_from_pointer(@_p.struct(3))
 
   :fun had_explicit_default: @_p.bool(0x10, 0b00000001)
 
-:struct CapnProto.Meta.Field.AS_group
+:struct box CapnProto.Meta.Field.AS_group
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
 
   :fun type_id: @_p.u64(0x10)
 
-:struct CapnProto.Meta.Field.AS_ordinal
+:struct box CapnProto.Meta.Field.AS_ordinal
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
@@ -210,38 +210,38 @@
   :fun is_explicit: @_p.check_union(0xa, 1)
   :fun explicit!: @_p.assert_union!(0xa, 1), @_p.u16(0xc)
 
-:struct CapnProto.Meta.Enumerant
+:struct box CapnProto.Meta.Enumerant
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
 
-  :fun ref name: @_p.text(0)
+  :fun name: @_p.text(0)
 
   :fun code_order: @_p.u16(0x0)
 
-  :fun ref annotations: CapnProto.List(CapnProto.Meta.Annotation).from_pointer(@_p.list(1))
+  :fun annotations: CapnProto.List(CapnProto.Meta.Annotation).read_from_pointer(@_p.list(1))
 
-:struct CapnProto.Meta.Superclass
+:struct box CapnProto.Meta.Superclass
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
 
   :fun id: @_p.u64(0x0)
 
-  :fun ref brand: CapnProto.Meta.Brand.from_pointer(@_p.struct(0))
+  :fun brand: CapnProto.Meta.Brand.read_from_pointer(@_p.struct(0))
 
-:struct CapnProto.Meta.Method
+:struct box CapnProto.Meta.Method
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 5
 
-  :fun ref name: @_p.text(0)
+  :fun name: @_p.text(0)
 
   :fun code_order: @_p.u16(0x0)
 
@@ -249,17 +249,17 @@
 
   :fun result_struct_type: @_p.u64(0x10)
 
-  :fun ref annotations: CapnProto.List(CapnProto.Meta.Annotation).from_pointer(@_p.list(1))
+  :fun annotations: CapnProto.List(CapnProto.Meta.Annotation).read_from_pointer(@_p.list(1))
 
-  :fun ref param_brand: CapnProto.Meta.Brand.from_pointer(@_p.struct(2))
+  :fun param_brand: CapnProto.Meta.Brand.read_from_pointer(@_p.struct(2))
 
-  :fun ref result_brand: CapnProto.Meta.Brand.from_pointer(@_p.struct(3))
+  :fun result_brand: CapnProto.Meta.Brand.read_from_pointer(@_p.struct(3))
 
-  :fun ref implicit_parameters: CapnProto.List(CapnProto.Meta.Node.Parameter).from_pointer(@_p.list(4))
+  :fun implicit_parameters: CapnProto.List(CapnProto.Meta.Node.Parameter).read_from_pointer(@_p.list(4))
 
-:struct CapnProto.Meta.Type
+:struct box CapnProto.Meta.Type
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
@@ -307,81 +307,81 @@
   :fun data!: @_p.assert_union!(0x0, 13), None
 
   :fun is_list: @_p.check_union(0x0, 14)
-  :fun ref list!: @_p.assert_union!(0x0, 14), CapnProto.Meta.Type.AS_list.from_pointer(@_p)
+  :fun list!: @_p.assert_union!(0x0, 14), CapnProto.Meta.Type.AS_list.read_from_pointer(@_p)
 
   :fun is_enum: @_p.check_union(0x0, 15)
-  :fun ref enum!: @_p.assert_union!(0x0, 15), CapnProto.Meta.Type.AS_enum.from_pointer(@_p)
+  :fun enum!: @_p.assert_union!(0x0, 15), CapnProto.Meta.Type.AS_enum.read_from_pointer(@_p)
 
   :fun is_struct: @_p.check_union(0x0, 16)
-  :fun ref struct!: @_p.assert_union!(0x0, 16), CapnProto.Meta.Type.AS_struct.from_pointer(@_p)
+  :fun struct!: @_p.assert_union!(0x0, 16), CapnProto.Meta.Type.AS_struct.read_from_pointer(@_p)
 
   :fun is_interface: @_p.check_union(0x0, 17)
-  :fun ref interface!: @_p.assert_union!(0x0, 17), CapnProto.Meta.Type.AS_interface.from_pointer(@_p)
+  :fun interface!: @_p.assert_union!(0x0, 17), CapnProto.Meta.Type.AS_interface.read_from_pointer(@_p)
 
   :fun is_any_pointer: @_p.check_union(0x0, 18)
-  :fun ref any_pointer!: @_p.assert_union!(0x0, 18), CapnProto.Meta.Type.AS_anyPointer.from_pointer(@_p)
+  :fun any_pointer!: @_p.assert_union!(0x0, 18), CapnProto.Meta.Type.AS_anyPointer.read_from_pointer(@_p)
 
-:struct CapnProto.Meta.Type.AS_list
+:struct box CapnProto.Meta.Type.AS_list
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
 
-  :fun ref element_type: CapnProto.Meta.Type.from_pointer(@_p.struct(0))
+  :fun element_type: CapnProto.Meta.Type.read_from_pointer(@_p.struct(0))
 
-:struct CapnProto.Meta.Type.AS_enum
+:struct box CapnProto.Meta.Type.AS_enum
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
-
-  :const capn_proto_data_word_count U16: 3
-  :const capn_proto_pointer_count U16: 1
-
-  :fun type_id: @_p.u64(0x8)
-
-  :fun ref brand: CapnProto.Meta.Brand.from_pointer(@_p.struct(0))
-
-:struct CapnProto.Meta.Type.AS_struct
-  :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
 
   :fun type_id: @_p.u64(0x8)
 
-  :fun ref brand: CapnProto.Meta.Brand.from_pointer(@_p.struct(0))
+  :fun brand: CapnProto.Meta.Brand.read_from_pointer(@_p.struct(0))
 
-:struct CapnProto.Meta.Type.AS_interface
+:struct box CapnProto.Meta.Type.AS_struct
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
 
   :fun type_id: @_p.u64(0x8)
 
-  :fun ref brand: CapnProto.Meta.Brand.from_pointer(@_p.struct(0))
+  :fun brand: CapnProto.Meta.Brand.read_from_pointer(@_p.struct(0))
 
-:struct CapnProto.Meta.Type.AS_anyPointer
+:struct box CapnProto.Meta.Type.AS_interface
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
+
+  :const capn_proto_data_word_count U16: 3
+  :const capn_proto_pointer_count U16: 1
+
+  :fun type_id: @_p.u64(0x8)
+
+  :fun brand: CapnProto.Meta.Brand.read_from_pointer(@_p.struct(0))
+
+:struct box CapnProto.Meta.Type.AS_anyPointer
+  :let _p CapnProto.Pointer.Struct
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
 
   :fun is_unconstrained: @_p.check_union(0x8, 0)
-  :fun ref unconstrained!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained.from_pointer(@_p)
+  :fun unconstrained!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained.read_from_pointer(@_p)
 
   :fun is_parameter: @_p.check_union(0x8, 1)
-  :fun ref parameter!: @_p.assert_union!(0x8, 1), CapnProto.Meta.Type.AS_anyPointer.AS_parameter.from_pointer(@_p)
+  :fun parameter!: @_p.assert_union!(0x8, 1), CapnProto.Meta.Type.AS_anyPointer.AS_parameter.read_from_pointer(@_p)
 
   :fun is_implicit_method_parameter: @_p.check_union(0x8, 2)
-  :fun ref implicit_method_parameter!: @_p.assert_union!(0x8, 2), CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter.from_pointer(@_p)
+  :fun implicit_method_parameter!: @_p.assert_union!(0x8, 2), CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter.read_from_pointer(@_p)
 
-:struct CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained
+:struct box CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
@@ -398,9 +398,9 @@
   :fun is_capability: @_p.check_union(0xa, 3)
   :fun capability!: @_p.assert_union!(0xa, 3), None
 
-:struct CapnProto.Meta.Type.AS_anyPointer.AS_parameter
+:struct box CapnProto.Meta.Type.AS_anyPointer.AS_parameter
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
@@ -409,27 +409,27 @@
 
   :fun parameter_index: @_p.u16(0xa)
 
-:struct CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter
+:struct box CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
 
   :fun parameter_index: @_p.u16(0xa)
 
-:struct CapnProto.Meta.Brand
+:struct box CapnProto.Meta.Brand
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 1
 
-  :fun ref scopes: CapnProto.List(CapnProto.Meta.Brand.Scope).from_pointer(@_p.list(0))
+  :fun scopes: CapnProto.List(CapnProto.Meta.Brand.Scope).read_from_pointer(@_p.list(0))
 
-:struct CapnProto.Meta.Brand.Scope
+:struct box CapnProto.Meta.Brand.Scope
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 2
   :const capn_proto_pointer_count U16: 1
@@ -437,14 +437,14 @@
   :fun scope_id: @_p.u64(0x0)
 
   :fun is_bind: @_p.check_union(0x8, 0)
-  :fun ref bind!: @_p.assert_union!(0x8, 0), CapnProto.List(CapnProto.Meta.Brand.Binding).from_pointer(@_p.list(0))
+  :fun bind!: @_p.assert_union!(0x8, 0), CapnProto.List(CapnProto.Meta.Brand.Binding).read_from_pointer(@_p.list(0))
 
   :fun is_inherit: @_p.check_union(0x8, 1)
   :fun inherit!: @_p.assert_union!(0x8, 1), None
 
-:struct CapnProto.Meta.Brand.Binding
+:struct box CapnProto.Meta.Brand.Binding
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
@@ -453,11 +453,11 @@
   :fun unbound!: @_p.assert_union!(0x0, 0), None
 
   :fun is_type: @_p.check_union(0x0, 1)
-  :fun ref type!: @_p.assert_union!(0x0, 1), CapnProto.Meta.Type.from_pointer(@_p.struct(0))
+  :fun type!: @_p.assert_union!(0x0, 1), CapnProto.Meta.Type.read_from_pointer(@_p.struct(0))
 
-:struct CapnProto.Meta.Value
+:struct box CapnProto.Meta.Value
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 2
   :const capn_proto_pointer_count U16: 1
@@ -499,38 +499,38 @@
   :fun float64!: @_p.assert_union!(0x0, 11), @_p.f64(0x8)
 
   :fun is_text: @_p.check_union(0x0, 12)
-  :fun ref text!: @_p.assert_union!(0x0, 12), @_p.text(0)
+  :fun text!: @_p.assert_union!(0x0, 12), @_p.text(0)
 
   :fun is_data: @_p.check_union(0x0, 13)
-  :fun ref data!: @_p.assert_union!(0x0, 13), @_p.data(0)
+  :fun data!: @_p.assert_union!(0x0, 13), @_p.data(0)
 
   :fun is_list: @_p.check_union(0x0, 14)
-  :fun ref list!: @_p.assert_union!(0x0, 14), None // UNHANDLED: anyPointer
+  :fun list!: @_p.assert_union!(0x0, 14), None // UNHANDLED: anyPointer
 
   :fun is_enum: @_p.check_union(0x0, 15)
   :fun enum!: @_p.assert_union!(0x0, 15), @_p.u16(0x2)
 
   :fun is_struct: @_p.check_union(0x0, 16)
-  :fun ref struct!: @_p.assert_union!(0x0, 16), None // UNHANDLED: anyPointer
+  :fun struct!: @_p.assert_union!(0x0, 16), None // UNHANDLED: anyPointer
 
   :fun is_interface: @_p.check_union(0x0, 17)
   :fun interface!: @_p.assert_union!(0x0, 17), None
 
   :fun is_any_pointer: @_p.check_union(0x0, 18)
-  :fun ref any_pointer!: @_p.assert_union!(0x0, 18), None // UNHANDLED: anyPointer
+  :fun any_pointer!: @_p.assert_union!(0x0, 18), None // UNHANDLED: anyPointer
 
-:struct CapnProto.Meta.Annotation
+:struct box CapnProto.Meta.Annotation
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
 
   :fun id: @_p.u64(0x0)
 
-  :fun ref value: CapnProto.Meta.Value.from_pointer(@_p.struct(0))
+  :fun value: CapnProto.Meta.Value.read_from_pointer(@_p.struct(0))
 
-  :fun ref brand: CapnProto.Meta.Brand.from_pointer(@_p.struct(1))
+  :fun brand: CapnProto.Meta.Brand.read_from_pointer(@_p.struct(1))
 
 :enum CapnProto.Meta.ElementSize
   :bit_width 16
@@ -551,40 +551,40 @@
       CapnProto.Meta.ElementSize.Empty
     )
 
-:struct CapnProto.Meta.CodeGeneratorRequest
+:struct box CapnProto.Meta.CodeGeneratorRequest
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 2
 
-  :fun ref nodes: CapnProto.List(CapnProto.Meta.Node).from_pointer(@_p.list(0))
+  :fun nodes: CapnProto.List(CapnProto.Meta.Node).read_from_pointer(@_p.list(0))
 
-  :fun ref requested_files: CapnProto.List(CapnProto.Meta.CodeGeneratorRequest.RequestedFile).from_pointer(@_p.list(1))
+  :fun requested_files: CapnProto.List(CapnProto.Meta.CodeGeneratorRequest.RequestedFile).read_from_pointer(@_p.list(1))
 
-:struct CapnProto.Meta.CodeGeneratorRequest.RequestedFile
+:struct box CapnProto.Meta.CodeGeneratorRequest.RequestedFile
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
 
   :fun id: @_p.u64(0x0)
 
-  :fun ref filename: @_p.text(0)
+  :fun filename: @_p.text(0)
 
-  :fun ref imports: CapnProto.List(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import).from_pointer(@_p.list(1))
+  :fun imports: CapnProto.List(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import).read_from_pointer(@_p.list(1))
 
-:struct CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import
+:struct box CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import
   :let _p CapnProto.Pointer.Struct
-  :new from_pointer(@_p)
+  :new box read_from_pointer(@_p)
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
 
   :fun id: @_p.u64(0x0)
 
-  :fun ref name: @_p.text(0)
+  :fun name: @_p.text(0)
 
 :struct CapnProto.Meta.Node.Builder
   :let _p CapnProto.Pointer.Struct.Builder

--- a/src/CapnProto.Pointer.Struct.savi
+++ b/src/CapnProto.Pointer.Struct.savi
@@ -1,18 +1,9 @@
-:trait _ParsedStructPointer
-  :new _new(
-    segments CapnProto.Segments
-    segment CapnProto.Segment
-    byte_offset U32
-    data_word_count U16
-    pointer_count U16
-  )
-
-:module _ParseStructPointer(A _ParsedStructPointer)
+:module _ParseStructPointer
   :fun _parse!(segments, segment, current_offset U32, value U64)
     // Handle the case that this may be a far pointer, pointing to the pointer.
     override_byte_offset U32 = -1
     try (
-      far = CapnProto.Pointer.Far._parse!(segments, segment, current_offset, value)
+      far = _FarPointer._parse!(segments, current_offset, value)
       segment = far._segment
       current_offset = far._byte_offset
       override_byte_offset = far._override_byte_offset
@@ -58,7 +49,20 @@
     data_word_count = value.bit_shr(32).u16
     pointer_count = value.bit_shr(48).u16
 
-    A._new(segments, segment, byte_offset, data_word_count, pointer_count)
+    CapnProto.Pointer.Struct._new(
+      segments, segment, byte_offset, data_word_count, pointer_count
+    )
+
+  :fun _parse_builder!(segments, segment, current_offset, value)
+    read_ptr = @_parse!(segments, segment, current_offset, value)
+    if (read_ptr._segment !== segment) (
+      try (segment = segments._list[segment._index]!)
+    )
+    CapnProto.Pointer.Struct.Builder._new(
+      segments, segment
+      read_ptr._byte_offset
+      read_ptr._data_word_count, read_ptr._pointer_count
+    )
 
 :module _WriteStructPointer
   :fun _encode_with_zero_relative_offset(
@@ -77,17 +81,17 @@
     pointer._data_word_count.u64.bit_shl(32)           // C
       .bit_or(pointer._pointer_count.u64.bit_shl(48)) // D (A and B are zero)
 
-:struct CapnProto.Pointer.Struct
-  :let _segments CapnProto.Segments
-  :let _segment CapnProto.Segment
+:struct box CapnProto.Pointer.Struct
+  :let _segments CapnProto.Segments'box
+  :let _segment CapnProto.Segment'box
   :let _byte_offset U32
   :let _data_word_count U16
   :let _pointer_count U16
-  :new _new(
+  :new box _new(
     @_segments, @_segment, @_byte_offset, @_data_word_count, @_pointer_count
   )
 
-  :new empty(@_segments, @_segment)
+  :new box empty(@_segments, @_segment)
     @_byte_offset = 0
     @_data_word_count = 0
     @_pointer_count = 0
@@ -99,7 +103,7 @@
   )
     segment = segments._list[segment_index]!
     value = segment._u64!(start_offset.u32)
-    _ParseStructPointer(CapnProto.Pointer.Struct)._parse!(
+    _ParseStructPointer._parse!(
       segments, segment, start_offset.u32, value
     )
 
@@ -123,22 +127,6 @@
     error! unless (@_data_word_count.u32 * 8 > n)
     @_segment._u64!(@_byte_offset +! n)
 
-  :fun ref _set_u8!(n U32, v U8)
-    error! unless (@_data_word_count.u32 * 8 > n)
-    @_segment._set_u8!(@_byte_offset +! n, v)
-
-  :fun ref _set_u16!(n U32, v U16)
-    error! unless (@_data_word_count.u32 * 8 > n)
-    @_segment._set_u16!(@_byte_offset +! n, v)
-
-  :fun ref _set_u32!(n U32, v U32)
-    error! unless (@_data_word_count.u32 * 8 > n)
-    @_segment._set_u32!(@_byte_offset +! n, v)
-
-  :fun ref _set_u64!(n U32, v U64)
-    error! unless (@_data_word_count.u32 * 8 > n)
-    @_segment._set_u64!(@_byte_offset +! n, v)
-
   :fun u8(n) U8: try (@_u8!(n) | 0)
   :fun u16(n) U16: try (@_u16!(n) | 0)
   :fun u32(n) U32: try (@_u32!(n) | 0)
@@ -157,45 +145,45 @@
   :fun assert_union!(n, value): error! if (@u16(n) != value)
   :fun check_union(n, value): @u16(n) == value
 
-  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
-  :fun ref text(n): try (@_text!(n) | @_empty_text)
-  :fun ref _empty_text
-    CapnProto.Text.from_pointer(
+  :fun text(n): try (@_text!(n) | @_empty_text)
+  :fun _empty_text
+    CapnProto.Text.read_from_pointer(
       CapnProto.Pointer.U8List.empty(@_segments, @_segment)
     )
-  :fun ref _text!(n)
+  :fun _text!(n)
     byte_offset = @_ptr_byte_offset!(n)
-    CapnProto.Text._parse!(
-      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+    CapnProto.Text.read_from_pointer(
+      _ParseU8ListPointer._parse!(
+        @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+      )
     )
 
-  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
-  :fun ref data(n): try (@_data!(n) | @_empty_data)
-  :fun ref _empty_data
+  :fun data(n): try (@_data!(n) | @_empty_data)
+  :fun _empty_data
     CapnProto.Data.from_pointer(CapnProto.Pointer.U8List.empty(@_segments, @_segment))
-  :fun ref _data!(n)
+  :fun _data!(n)
     byte_offset = @_ptr_byte_offset!(n)
-    CapnProto.Data._parse!(
-      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+    CapnProto.Data.read_from_pointer(
+      _ParseU8ListPointer._parse!(
+        @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+      )
     )
 
-  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
-  :fun ref struct(n): try (@_struct!(n) | @_empty_struct)
-  :fun ref _empty_struct
+  :fun struct(n): try (@_struct!(n) | @_empty_struct)
+  :fun _empty_struct
     CapnProto.Pointer.Struct.empty(@_segments, @_segment)
-  :fun ref _struct!(n):
+  :fun _struct!(n):
     byte_offset = @_ptr_byte_offset!(n)
-    _ParseStructPointer(CapnProto.Pointer.Struct)._parse!(
+    _ParseStructPointer._parse!(
       @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
     )
 
-  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
-  :fun ref list(n): try (@_list!(n) | @_empty_list)
-  :fun ref _empty_list
+  :fun list(n): try (@_list!(n) | @_empty_list)
+  :fun _empty_list
     CapnProto.Pointer.StructList.empty(@_segments, @_segment)
-  :fun ref _list!(n):
+  :fun _list!(n):
     byte_offset = @_ptr_byte_offset!(n)
-    _ParseStructListPointer(CapnProto.Pointer.StructList)._parse!(
+    _ParseStructListPointer._parse!(
       @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
     )
 
@@ -221,7 +209,7 @@
   )
     segment = segments._list[segment_index]!
     value = segment._u64!(start_offset.u32)
-    _ParseStructPointer(CapnProto.Pointer.Struct)._parse!(
+    _ParseStructPointer._parse!(
       segments, segment, start_offset.u32, value
     )
 
@@ -300,7 +288,6 @@
   :fun assert_union!(n, value): error! if (@u16(n) != value)
   :fun check_union(n, value): @u16(n) == value
 
-  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
   :fun ref text(n): try (@_text!(n) | @_empty_text)
   :fun ref _empty_text
     CapnProto.Text.from_pointer(
@@ -308,8 +295,10 @@
     )
   :fun ref _text!(n)
     byte_offset = @_ptr_byte_offset!(n)
-    CapnProto.Text._parse!(
-      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+    CapnProto.Text.from_pointer(
+      _ParseU8ListPointer._parse_builder!(
+        @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+      )
     )
 
   :fun ref set_text(n, value String, default_value String) CapnProto.Text
@@ -319,10 +308,10 @@
     // and we'll return an empty `CapnProto.Text` to signal this problem.
     byte_offset = try (@_ptr_byte_offset!(n) | return @_empty_text)
 
-    // If there's an existing text pointer, we can free it now.
-    try CapnProto.Text._parse!(
+    // If there's an existing pointer, we can free it now.
+    try _ParseU8ListPointer._parse_builder!(
       @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
-    )._p._free
+    )._free(@_segment)
 
     // If the requested value is empty, we won't allocate anything new.
     // We'll just write zero bytes to that pointer's position and return.
@@ -342,14 +331,15 @@
 
     new_text
 
-  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
   :fun ref data(n): try (@_data!(n) | @_empty_data)
   :fun ref _empty_data
     CapnProto.Data.from_pointer(CapnProto.Pointer.U8List.empty(@_segments, @_segment))
   :fun ref _data!(n)
     byte_offset = @_ptr_byte_offset!(n)
-    CapnProto.Data._parse!(
-      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+    CapnProto.Data.from_pointer(
+      _ParseU8ListPointer._parse_builder!(
+        @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+      )
     )
 
   :fun ref set_data(n, value Bytes, default_value Bytes) CapnProto.Data
@@ -359,10 +349,10 @@
     // and we'll return an empty `CapnProto.Data` to signal this problem.
     byte_offset = try (@_ptr_byte_offset!(n) | return @_empty_data)
 
-    // If there's an existing data pointer, we can free it now.
-    try CapnProto.Data._parse!(
+    // If there's an existing pointer, we can free it now.
+    try _ParseU8ListPointer._parse_builder!(
       @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
-    )._p._free
+    )._free(@_segment)
 
     // If the requested value is empty, we won't allocate anything new.
     // We'll just write zero bytes to that pointer's position and return.
@@ -382,23 +372,21 @@
 
     new_data
 
-  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
   :fun ref struct(n): try (@_struct!(n) | @_empty_struct)
   :fun ref _empty_struct
     CapnProto.Pointer.Struct.Builder.empty(@_segments, @_segment)
   :fun ref _struct!(n):
     byte_offset = @_ptr_byte_offset!(n)
-    _ParseStructPointer(CapnProto.Pointer.Struct.Builder)._parse!(
+    _ParseStructPointer._parse_builder!(
       @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
     )
 
-  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
   :fun ref list(n): try (@_list!(n) | @_empty_list)
   :fun ref _empty_list
     CapnProto.Pointer.StructList.Builder.empty(@_segments, @_segment)
   :fun ref _list!(n):
     byte_offset = @_ptr_byte_offset!(n)
-    _ParseStructListPointer(CapnProto.Pointer.StructList.Builder)._parse!(
+    _ParseStructListPointer._parse_builder!(
       @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
     )
 
@@ -413,7 +401,7 @@
     byte_offset = try (@_ptr_byte_offset!(n) | return @_empty_list)
 
     // If there's an existing list pointer, we can free it now.
-    try _ParseStructListPointer(CapnProto.Pointer.StructList.Builder)._parse!(
+    try _ParseStructListPointer._parse_builder!(
       @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
     )._free
 

--- a/src/CapnProto.Pointer.StructList.savi
+++ b/src/CapnProto.Pointer.StructList.savi
@@ -9,12 +9,12 @@
     pointer_count U16
   )
 
-:module _ParseStructListPointer(A _ParsedStructListPointer)
-  :fun non _parse!(segments, segment, current_offset U32, value U64) A
+:module _ParseStructListPointer
+  :fun non _parse!(segments, segment, current_offset U32, value U64)
     // Handle the case that this may be a far pointer, pointing to the pointer.
     override_byte_offset U32 = -1
     try (
-      far = CapnProto.Pointer.Far._parse!(segments, segment, current_offset, value)
+      far = _FarPointer._parse!(segments, current_offset, value)
       segment = far._segment
       current_offset = far._byte_offset
       override_byte_offset = far._override_byte_offset
@@ -80,7 +80,9 @@
     // (D) indicate the number of 8-byte words of space needed for the list,
     // which is distinct from the number of elements in the list.
     word_count = upper_32.bit_shr(3).usize
-    return A.empty(segments, segment) if (word_count == 0)
+    if (word_count == 0) (
+      return CapnProto.Pointer.StructList.empty(segments, segment)
+    )
 
     // Read the tag pointer, which is similar to a struct pointer,
     // and describes the individual size of all structs in the list,
@@ -91,13 +93,28 @@
     data_word_count = tag_value.bit_shr(32).u16
     pointer_count = tag_value.bit_shr(48).u16
 
-    A._new(
+    CapnProto.Pointer.StructList._new(
       segments
       segment
       byte_offset
       list_count
       data_word_count
       pointer_count
+    )
+
+  :fun _parse_builder!(
+    segments CapnProto.Segments
+    segment CapnProto.Segment
+    current_offset, value
+  )
+    read_ptr = @_parse!(segments, segment, current_offset, value)
+    if (read_ptr._segment !== segment) (
+      try (segment = segments._list[segment._index]!)
+    )
+    CapnProto.Pointer.StructList.Builder._new(
+      segments, segment
+      read_ptr._byte_offset, read_ptr._list_count
+      read_ptr._data_word_count, read_ptr._pointer_count
     )
 
 :module _WriteStructListPointer
@@ -140,14 +157,14 @@
       .bit_or(pointer._data_word_count.u64.bit_shl(32))    // C
       .bit_or(pointer._pointer_count.u64.bit_shl(48))      // D (A is zero)
 
-:struct CapnProto.Pointer.StructList
-  :let _segments CapnProto.Segments
-  :let _segment CapnProto.Segment
+:struct box CapnProto.Pointer.StructList
+  :let _segments CapnProto.Segments'box
+  :let _segment CapnProto.Segment'box
   :let _byte_offset U32
   :let _list_count U32
   :let _data_word_count U16
   :let _pointer_count U16
-  :new _new(
+  :new box _new(
     @_segments
     @_segment
     @_byte_offset
@@ -156,7 +173,7 @@
     @_pointer_count
   )
 
-  :new empty(@_segments, @_segment)
+  :new box empty(@_segments, @_segment)
     @_byte_offset = 0
     @_list_count = 0
     @_data_word_count = 0
@@ -171,12 +188,11 @@
   )
     segment = segments._list[segment_index]!
     value = segment._u64!(start_offset.u32)
-    _ParseStructListPointer(CapnProto.Pointer.StructList)._parse!(
+    _ParseStructListPointer._parse!(
       segments, segment, start_offset.u32, value
     )
 
-  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
-  :fun ref "[]!"(n U32)
+  :fun "[]!"(n U32)
     error! unless (n < @_list_count)
 
     byte_offset = @_byte_offset +! @_element_byte_size *! n
@@ -185,8 +201,7 @@
       @_segments, @_segment, byte_offset, @_data_word_count, @_pointer_count
     )
 
-  // TODO: Deal with the ref/val/box possibilities here instead of assuming ref
-  :fun ref each
+  :fun each
     @_list_count.times -> (n |
       try (
         byte_offset = @_byte_offset +! @_element_byte_size *! n
@@ -264,7 +279,7 @@
   )
     segment = segments._list[segment_index]!
     value = segment._u64!(start_offset.u32)
-    _ParseStructListPointer(CapnProto.Pointer.StructList.Builder)._parse!(
+    _ParseStructListPointer._parse_builder!(
       segments, segment, start_offset.u32, value
     )
 

--- a/src/CapnProto.Pointer.U8List.savi
+++ b/src/CapnProto.Pointer.U8List.savi
@@ -1,63 +1,9 @@
-:module _WriteU8ListPointer
-  :fun _encode(
-    write_offset U32
-    pointer CapnProto.Pointer.U8List
-  )
-    // lsb                       list pointer                        msb
-    // +-+-----------------------------+--+----------------------------+
-    // |A|             B               |C |             D              |
-    // +-+-----------------------------+--+----------------------------+
-
-    // A (2 bits) = 1, to indicate that this is a list pointer.
-    // B (30 bits) = Offset, in words, from the end of the pointer to the
-    //     start of the first element of the list.  Signed.
-    // C (3 bits) = Size of each element:
-    //     0 = 0 (e.g. List(Void))
-    //     1 = 1 bit
-    //     2 = 1 byte
-    //     3 = 2 bytes
-    //     4 = 4 bytes
-    //     5 = 8 bytes (non-pointer)
-    //     6 = 8 bytes (pointer)
-    //     7 = composite (see below)
-    // D (29 bits) = Size of the list:
-    //     when C <> 7: Number of elements in the list.
-    //     when C = 7: Number of words in the list, not counting the tag word
-    //     (see below).
-
-    relative_words = (pointer._byte_offset / 8).i32 - (write_offset / 8).i32 - 1
-
-    pointer._byte_count.at_most(0x1FFFFFFF).u64.bit_shl(35) // D
-      .bit_or(relative_words.u64.bit_shl(2))                // B
-      .bit_or(0x0000000200000001)                           // A and C
-
-:struct CapnProto.Pointer.U8List
-  :let _segments CapnProto.Segments
-  :let _segment CapnProto.Segment
-  :let _byte_offset U32
-  :let _byte_count U32
-  :new _new(@_segments, @_segment, @_byte_offset, @_byte_count)
-
-  :new empty(@_segments, @_segment)
-    @_byte_offset = 0
-    @_byte_count = 0
-
-  :fun ref _free: @_segment._free_pointer(@_byte_offset, @_byte_count), @
-
-  :fun non from_segments!(
-    segments CapnProto.Segments
-    start_offset USize = 0
-    segment_index USize = 0
-  )
-    segment = segments._list[segment_index]!
-    value = segment._u64!(start_offset.u32)
-    @_parse!(segments, segment, start_offset.u32, value)
-
+:module _ParseU8ListPointer
   :fun non _parse!(segments, segment, current_offset U32, value U64)
     // Handle the case that this may be a far pointer, pointing to the pointer.
     override_byte_offset U32 = -1
     try (
-      far = CapnProto.Pointer.Far._parse!(segments, segment, current_offset, value)
+      far = _FarPointer._parse!(segments, current_offset, value)
       segment = far._segment
       current_offset = far._byte_offset
       override_byte_offset = far._override_byte_offset
@@ -123,7 +69,81 @@
     // the number of bytes in the list, because this list is of the byte class.
     byte_count = upper_32.bit_shr(3).u32
 
-    @_new(segments, segment, byte_offset, byte_count)
+    CapnProto.Pointer.U8List._new_read(
+      segments, segment, byte_offset, byte_count
+    )
+
+  :fun _parse_builder!(
+    segments CapnProto.Segments
+    segment CapnProto.Segment
+    current_offset, value
+  )
+    read_ptr = @_parse!(segments, segment, current_offset, value)
+    if (read_ptr._segment !== segment) (
+      try (segment = segments._list[segment._index]!)
+    )
+    CapnProto.Pointer.U8List._new_read(
+      segments, segment
+      read_ptr._byte_offset, read_ptr._byte_count
+    )
+
+:module _WriteU8ListPointer
+  :fun _encode(
+    write_offset U32
+    pointer CapnProto.Pointer.U8List'box
+  )
+    // lsb                       list pointer                        msb
+    // +-+-----------------------------+--+----------------------------+
+    // |A|             B               |C |             D              |
+    // +-+-----------------------------+--+----------------------------+
+
+    // A (2 bits) = 1, to indicate that this is a list pointer.
+    // B (30 bits) = Offset, in words, from the end of the pointer to the
+    //     start of the first element of the list.  Signed.
+    // C (3 bits) = Size of each element:
+    //     0 = 0 (e.g. List(Void))
+    //     1 = 1 bit
+    //     2 = 1 byte
+    //     3 = 2 bytes
+    //     4 = 4 bytes
+    //     5 = 8 bytes (non-pointer)
+    //     6 = 8 bytes (pointer)
+    //     7 = composite (see below)
+    // D (29 bits) = Size of the list:
+    //     when C <> 7: Number of elements in the list.
+    //     when C = 7: Number of words in the list, not counting the tag word
+    //     (see below).
+
+    relative_words = (pointer._byte_offset / 8).i32 - (write_offset / 8).i32 - 1
+
+    pointer._byte_count.at_most(0x1FFFFFFF).u64.bit_shl(35) // D
+      .bit_or(relative_words.u64.bit_shl(2))                // B
+      .bit_or(0x0000000200000001)                           // A and C
+
+:struct CapnProto.Pointer.U8List
+  :let _segments CapnProto.Segments'box
+  :let _segment CapnProto.Segment'box
+  :let _byte_offset U32
+  :let _byte_count U32
+  :new box _new_read(@_segments, @_segment, @_byte_offset, @_byte_count)
+
+  :new box empty(@_segments, @_segment)
+    @_byte_offset = 0
+    @_byte_count = 0
+
+  :fun _free(segment CapnProto.Segment)
+    if (segment === @_segment) (
+      segment._free_pointer(@_byte_offset, @_byte_count), @
+    )
+
+  :fun non from_segments!(
+    segments CapnProto.Segments
+    start_offset USize = 0
+    segment_index USize = 0
+  )
+    segment = segments._list[segment_index]!
+    value = segment._u64!(start_offset.u32)
+    _ParseU8ListPointer._parse!(segments, segment, start_offset.u32, value)
 
   :is Indexable(U8)
 

--- a/src/CapnProto.Segment.savi
+++ b/src/CapnProto.Segment.savi
@@ -1,13 +1,19 @@
-:struct CapnProto.Segment
+:class CapnProto.Segment
+  :let _segments CapnProto.Segments
   :let _bytes Bytes'ref
   :let _holes Array(Pair(U32))
+  :let _index USize
 
-  :new new_from_bytes(@_bytes, @_holes = [])
+  :new new_from_bytes(@_segments, @_bytes, @_holes = [])
+    @_index = @_segments._list.size
+    @_segments._list << @
 
-  :new (space USize)
+  :new (@_segments, space USize)
     @_bytes = Bytes.new(space)
     @_bytes.fill_with_zeros(0, @_bytes.space)
     @_holes = [Pair(U32).new(0, space.u32)]
+    @_index = @_segments._list.size
+    @_segments._list << @
 
   :fun _u8!(offset U32): @_bytes[offset.usize]!
   :fun _u16!(offset U32): @_bytes.read_native_u16!(offset.usize).le_to_native

--- a/src/CapnProto.Segments.savi
+++ b/src/CapnProto.Segments.savi
@@ -1,12 +1,12 @@
 :struct CapnProto.Segments
   :let _list Array(CapnProto.Segment)'ref
-  :new (@_list)
+  :new: @_list = []
 
 :class CapnProto.Segments.Reader
   :var _header: b""
-  :var _segments: CapnProto.Segments.new([]) // TODO: iso
+  :var _segments: CapnProto.Segments.new // TODO: iso
 
-  :fun ref take_segments: @_segments <<= CapnProto.Segments.new([])
+  :fun ref take_segments: @_segments <<= CapnProto.Segments.new
 
   :: The maximum total size that the segment buffers are allowed to allocate.
   ::
@@ -106,7 +106,8 @@
       segment_id = @_segments._list.size
       segment_size = @_expected_segment_size(segment_id)
       try (
-        @_segments._list << CapnProto.Segment.new_from_bytes(
+        CapnProto.Segment.new_from_bytes(
+          @_segments
           stream.advance!(segment_size).extract_token
         )
       |

--- a/src/CapnProto.Text.savi
+++ b/src/CapnProto.Text.savi
@@ -1,16 +1,12 @@
 :struct CapnProto.Text
-  :let _p CapnProto.Pointer.U8List
+  :let _p CapnProto.Pointer.U8List'box
   :new from_pointer(@_p)
+  :new box read_from_pointer(p CapnProto.Pointer.U8List'box): @_p = p
 
-  :new _new(segments, segment, value String)
+  :new _new(segments, segment CapnProto.Segment, value String)
     byte_offset = segment._allocate_and_write_string(value)
-    @_p = CapnProto.Pointer.U8List._new(
+    @_p = CapnProto.Pointer.U8List._new_read(
       segments, segment, byte_offset, (value.size + 1).u32
-    )
-
-  :fun non _parse!(segments, segment, current_offset, value)
-    @from_pointer(
-      CapnProto.Pointer.U8List._parse!(segments, segment, current_offset, value)
     )
 
   :fun size: @_p._byte_count.usize.saturating_subtract(1) // trimming off the null terminator

--- a/src/_FarPointer.savi
+++ b/src/_FarPointer.savi
@@ -1,11 +1,9 @@
-:struct CapnProto.Pointer.Far
-  :let _segments CapnProto.Segments
-  :let _segment CapnProto.Segment
+:struct _FarPointer
+  :let _segment CapnProto.Segment'box
   :let _byte_offset U32
   :let _override_byte_offset U32
   :let _pointer_value U64
   :new _new(
-    @_segments
     @_segment
     @_byte_offset
     @_override_byte_offset
@@ -13,8 +11,7 @@
   )
 
   :fun non _parse!(
-    segments CapnProto.Segments
-    current_segment CapnProto.Segment
+    segments CapnProto.Segments'box
     current_offset U32
     value U64
   )
@@ -49,8 +46,8 @@
 
     // The upper 32-bits of the value (D), represent the segment ID, as an
     // index into the list of segments to point to the target segment.
-    segment_id = value.bit_shr(32).u32
-    segment = segments._list[segment_id.usize]!
+    segment_index = value.bit_shr(32).u32.usize
+    segment = segments._list[segment_index]!
 
     // The pointer value pointed to by the far pointer is retrieved from that
     // particular byte offset within the target segment.
@@ -74,11 +71,11 @@
       tag_pointer_value = segment._u64!(byte_offset +! 8)
 
       // We follow the second far pointer to the second target segment.
-      segment_id = pointer_value.bit_shr(32).u32
-      segment = segments._list[segment_id.usize]!
+      segment_index = pointer_value.bit_shr(32).u32.usize
+      segment = segments._list[segment_index]!
 
       // And we treat the tag pointer value as the one that describes the data.
       pointer_value = tag_pointer_value
     )
 
-    @_new(segments, segment, byte_offset, override_byte_offset, pointer_value)
+    @_new(segment, byte_offset, override_byte_offset, pointer_value)

--- a/src/capnpc-savi/Main.savi
+++ b/src/capnpc-savi/Main.savi
@@ -22,7 +22,7 @@
     try (
       segments = @_reader.take_segments
       pointer = CapnProto.Pointer.Struct.from_segments!(segments)
-      req = CapnProto.Meta.CodeGeneratorRequest.from_pointer(pointer)
+      req = CapnProto.Meta.CodeGeneratorRequest.read_from_pointer(pointer)
       @_generate(req)
     |
       @env.err.print("Failed to parse the root of the capnpc data")

--- a/src/capnpc-savi/_Gen.savi
+++ b/src/capnpc-savi/_Gen.savi
@@ -6,23 +6,20 @@
 
   :fun ref take_string: @_out <<= String.new_iso
 
-  // TODO: not `:fun ref`
-  :fun ref _find_node!(id U64) CapnProto.Meta.Node
+  :fun _find_node!(id U64) CapnProto.Meta.Node
     @req.nodes.each -> (node |
       return node if (node.id == id)
     )
     error!
 
-  // TODO: not `:fun ref`
-  :fun ref _find_node_scoped_name(id U64) String
+  :fun _find_node_scoped_name(id U64) String
     try (
       @_node_scoped_name(@_find_node!(id))
     |
       "UNKNOWN_ID"
     )
 
-  // TODO: not `:fun ref`
-  :fun ref _node_scoped_name(node CapnProto.Meta.Node) String
+  :fun _node_scoped_name(node CapnProto.Meta.Node) String
     try (
       case (
       | node.is_file |
@@ -36,8 +33,7 @@
       "UNKNOWN_NAME"
     )
 
-  // TODO: not `:fun ref`
-  :fun ref _node_scoped_name_of_group!(node CapnProto.Meta.Node) String
+  :fun _node_scoped_name_of_group!(node CapnProto.Meta.Node) String
     scope_node = @_find_node!(node.scope_id)
     scope_node.struct!.fields.each -> (field |
       try (
@@ -48,8 +44,7 @@
     )
     error!
 
-  // TODO: not `:fun ref`
-  :fun ref _node_scoped_name_of_typedecl!(node CapnProto.Meta.Node) String
+  :fun _node_scoped_name_of_typedecl!(node CapnProto.Meta.Node) String
     scope_node = @_find_node!(node.scope_id)
     scope_node.nested_nodes.each -> (nested |
       if (nested.id == node.id) (
@@ -58,13 +53,11 @@
     )
     error!
 
-  // TODO: not `:fun ref`
-  :fun ref _is_pointer_type(type CapnProto.Meta.Type)
+  :fun _is_pointer_type(type CapnProto.Meta.Type)
     type.is_text || type.is_data || type.is_list
     || type.is_struct || type.is_interface || type.is_any_pointer
 
-  // TODO: not `:fun ref`
-  :fun ref _type_name(t CapnProto.Meta.Type, is_builder Bool)
+  :fun _type_name(t CapnProto.Meta.Type, is_builder Bool)
     case (
     | t.is_void | "None"
     | t.is_bool | "Bool"
@@ -98,8 +91,7 @@
     | "NOT_IMPLEMENTED"
     )
 
-  // TODO: not `:fun ref`
-  :fun ref _show_value(value CapnProto.Meta.Value) String
+  :fun _show_value(value CapnProto.Meta.Value) String
     return "None" if value.is_void
     try (string = "\(value.bool!)",    return --string) // TODO: this local variable shouldn't be needed
     try (string = "\(value.int8!)",    return --string) // TODO: this local variable shouldn't be needed
@@ -163,11 +155,19 @@
     @_out << "\n    )"
 
   :fun ref _emit_struct(node CapnProto.Meta.Node, is_builder Bool)
-    @_out << "\n\n:struct \(@_node_scoped_name(node))"
-    if is_builder (@_out << ".Builder")
-    @_out << "\n  :let _p CapnProto.Pointer.Struct"
-    if is_builder (@_out << ".Builder")
-    @_out << "\n  :new from_pointer(@_p)"
+    @_out << "\n\n:struct \(
+      if !is_builder "box "
+    )\(
+      @_node_scoped_name(node)
+    )\(
+      if is_builder ".Builder"
+    )"
+    @_out << "\n  :let _p CapnProto.Pointer.Struct\(
+      if is_builder ".Builder"
+    )"
+    @_out << "\n  :new \(
+      if !is_builder "box read_"
+    )from_pointer(@_p)"
 
     // Emit protocol-level constant info.
     try (
@@ -229,9 +229,9 @@
     is_builder Bool
   )
     is_union = field.discriminant_value != field.no_discriminant
-    needs_ref = try (@_is_pointer_type(field.slot!.type) | True)
+    needs_ref = is_builder && try (@_is_pointer_type(field.slot!.type) | True)
     @_out << "\n  :fun\(
-      if needs_ref " ref" // TODO: remove this `ref`
+      if needs_ref " ref"
     ) \(_TextCase.Snake[field.name])\(
       if is_union "!"
     ): "
@@ -317,8 +317,8 @@
       @_out << "\(
         @_find_node_scoped_name(type_id)
       )\(
-        if is_builder (".Builder" | "")
-      ).from_pointer(@_p)"
+        if is_builder (".Builder.from_pointer" | ".read_from_pointer")
+      )(@_p)"
       return
     )
 
@@ -423,14 +423,17 @@
       )
     | type.is_data |
       @_out << "@_p.data(\(offset))"
-      try (
-        if (slot.default_value.data!.size > 0) (
-          @_out << " // UNHANDLED: default_value"
-        )
-      )
+    //   TODO: Handle default value:
+    //   try (
+    //     if (slot.default_value.data!.size > 0) (
+    //       @_out << " // UNHANDLED: default_value"
+    //     )
+    //   )
     | type.is_list |
       // TODO: handle default list values
-      @_out << "\(@_type_name(type, is_builder)).from_pointer(@_p.list(\(offset)))"
+      @_out << "\(@_type_name(type, is_builder)).\(
+        if is_builder ("" | "read_")
+      )from_pointer(@_p.list(\(offset)))"
     | type.is_enum |
       @_out << "\(@_type_name(type, is_builder))._new("
       @_out << "@_p.u16(\((offset * 2).format.hex.without_leading_zeros))"
@@ -442,7 +445,9 @@
       @_out << ")"
     | type.is_struct |
       // TODO: handle default list values
-      @_out << "\(@_type_name(type, is_builder)).from_pointer(@_p.struct(\(offset)))"
+      @_out << "\(@_type_name(type, is_builder)).\(
+        if is_builder ("" | "read_")
+      )from_pointer(@_p.struct(\(offset)))"
     | type.is_interface |
       @_out << "None // UNHANDLED: interface" // TODO: handle interfaces
     | type.is_any_pointer |

--- a/src/capnpc-savi/_TextCase.savi
+++ b/src/capnpc-savi/_TextCase.savi
@@ -1,6 +1,6 @@
 // TODO: Move this utility to more generally available library?
 :struct _TextCase.Snake
-  :let _text CapnProto.Text // TODO: make this work on a more general interface
+  :let _text CapnProto.Text'box // TODO: make this work on a more general interface
   :new (@_text)
   :fun non "[]"(text): @new(text) // convenience constructor
 
@@ -20,7 +20,7 @@
 
 // TODO: Move this utility to more generally available library?
 :struct _TextCase.Pascal
-  :let _text CapnProto.Text // TODO: make this work on a more general interface
+  :let _text CapnProto.Text'box // TODO: make this work on a more general interface
   :new (@_text)
   :fun non "[]"(text): @new(text) // convenience constructor
 


### PR DESCRIPTION
This finishes the basic delineation between the two concepts.

Builders are used for building, and are mutable.
Non-Builder views are read-only.