### PR TITLE
Refactor to remove some unnecessary things...

### DIFF
--- a/spec/CapnProto.Pointer.Struct.Builder.Spec.savi
+++ b/spec/CapnProto.Pointer.Struct.Builder.Spec.savi
@@ -7,7 +7,7 @@
     segments = CapnProto.Segments.new
     segment = CapnProto.Segment.new(segments, byte_size)
     CapnProto.Pointer.Struct.Builder._new(
-      segments, segment, 0, data_word_count, pointer_count
+      segment, 0, data_word_count, pointer_count
     )
 
   :it "writes and reads numeric values in the data region"

--- a/spec/CapnProto.Pointer.Struct.Spec.savi
+++ b/spec/CapnProto.Pointer.Struct.Spec.savi
@@ -5,9 +5,10 @@
   :fun from_segment(bytes Bytes, byte_offset USize = 0)
     segments = CapnProto.Segments.new
     segment = CapnProto.Segment.new_from_bytes(segments, bytes.clone)
-    pointer = CapnProto.Pointer.Struct.empty(segments, segment)
+    pointer = CapnProto.Pointer.Struct.empty(segment)
     assert no_error: (
-      pointer = CapnProto.Pointer.Struct.from_segments!(segments, byte_offset)
+      ptr_value = segment._u64!(byte_offset.u32)
+      pointer = _ParseStructPointer._parse!(segment, byte_offset.u32, ptr_value)
     )
     pointer
 
@@ -17,9 +18,10 @@
       CapnProto.Segment.new_from_bytes(segments, chunk.clone)
     )
     segment = try (segments._list[0]! | CapnProto.Segment.new_from_bytes(segments, b"".clone))
-    pointer = CapnProto.Pointer.Struct.empty(segments, segment)
+    pointer = CapnProto.Pointer.Struct.empty(segment)
     assert no_error: (
-      pointer = CapnProto.Pointer.Struct.from_segments!(segments, byte_offset)
+      ptr_value = segment._u64!(byte_offset.u32)
+      pointer = _ParseStructPointer._parse!(segment, byte_offset.u32, ptr_value)
     )
     pointer
 

--- a/spec/CapnProto.Pointer.StructList.Spec.savi
+++ b/spec/CapnProto.Pointer.StructList.Spec.savi
@@ -5,9 +5,10 @@
   :fun from_segment(bytes Bytes, byte_offset USize = 0)
     segments = CapnProto.Segments.new
     segment = CapnProto.Segment.new_from_bytes(segments, bytes.clone)
-    pointer = CapnProto.Pointer.StructList.empty(segments, segment)
+    pointer = CapnProto.Pointer.StructList.empty(segment)
     assert no_error: (
-      pointer = CapnProto.Pointer.StructList.from_segments!(segments, byte_offset)
+      ptr_value = segment._u64!(byte_offset.u32)
+      pointer = _ParseStructListPointer._parse!(segment, byte_offset.u32, ptr_value)
     )
     pointer
 
@@ -17,9 +18,10 @@
       CapnProto.Segment.new_from_bytes(segments, chunk.clone)
     )
     segment = try (segments._list[0]! | CapnProto.Segment.new_from_bytes(segments, b"".clone))
-    pointer = CapnProto.Pointer.StructList.empty(segments, segment)
+    pointer = CapnProto.Pointer.StructList.empty(segment)
     assert no_error: (
-      pointer = CapnProto.Pointer.StructList.from_segments!(segments, byte_offset)
+      ptr_value = segment._u64!(byte_offset.u32)
+      pointer = _ParseStructListPointer._parse!(segment, byte_offset.u32, ptr_value)
     )
     pointer
 

--- a/spec/CapnProto.Pointer.U8List.Spec.savi
+++ b/spec/CapnProto.Pointer.U8List.Spec.savi
@@ -5,9 +5,10 @@
   :fun from_segment(bytes Bytes, byte_offset USize = 0)
     segments = CapnProto.Segments.new
     segment = CapnProto.Segment.new_from_bytes(segments, bytes.clone)
-    pointer = CapnProto.Pointer.U8List.empty(segments, segment)
+    pointer = CapnProto.Pointer.U8List.empty(segment)
     assert no_error: (
-      pointer = CapnProto.Pointer.U8List.from_segments!(segments, byte_offset)
+      ptr_value = segment._u64!(byte_offset.u32)
+      pointer = _ParseU8ListPointer._parse!(segment, byte_offset.u32, ptr_value)
     )
     pointer
 
@@ -17,9 +18,10 @@
       CapnProto.Segment.new_from_bytes(segments, chunk.clone)
     )
     segment = try (segments._list[0]! | CapnProto.Segment.new_from_bytes(segments, b"".clone))
-    pointer = CapnProto.Pointer.U8List.empty(segments, segment)
+    pointer = CapnProto.Pointer.U8List.empty(segment)
     assert no_error: (
-      pointer = CapnProto.Pointer.U8List.from_segments!(segments, byte_offset)
+      ptr_value = segment._u64!(byte_offset.u32)
+      pointer = _ParseU8ListPointer._parse!(segment, byte_offset.u32, ptr_value)
     )
     pointer
 

--- a/src/CapnProto.Data.savi
+++ b/src/CapnProto.Data.savi
@@ -3,10 +3,10 @@
   :new from_pointer(@_p)
   :new box read_from_pointer(p CapnProto.Pointer.U8List'box): @_p = p
 
-  :new _new(segments, segment CapnProto.Segment, value Bytes)
+  :new _new(segment CapnProto.Segment, value Bytes)
     byte_offset = segment._allocate_and_write_bytes(value)
     @_p = CapnProto.Pointer.U8List._new_read(
-      segments, segment, byte_offset, value.size.u32
+      segment, byte_offset, value.size.u32
     )
 
   :fun size: @_p._byte_count.usize

--- a/src/CapnProto.Message.savi
+++ b/src/CapnProto.Message.savi
@@ -1,3 +1,20 @@
+:trait box _MessageRoot
+  :new box read_from_pointer(p CapnProto.Pointer.Struct)
+
+:struct box CapnProto.Message(A _MessageRoot)
+  :let root A
+  :new box (@root)
+
+  :fun non from_segments!(
+    segments CapnProto.Segments
+    start_offset USize = 0
+    segment_index USize = 0
+  )
+    segment = segments._list[segment_index]!
+    value = segment._u64!(start_offset.u32)
+    pointer = _ParseStructPointer._parse!(segment, start_offset.u32, value)
+    @new(A.read_from_pointer(pointer))
+
 :trait _MessageBuilderRoot
   :new from_pointer(p CapnProto.Pointer.Struct.Builder)
 
@@ -17,8 +34,7 @@
     segments = CapnProto.Segments.new
     segment = CapnProto.Segment.new(segments, initial_size)
     pointer = CapnProto.Pointer.Struct.Builder._new(
-      segments, segment, 8
-      A.capn_proto_data_word_count, A.capn_proto_pointer_count
+      segment, 8, A.capn_proto_data_word_count, A.capn_proto_pointer_count
     )
     try segment._set_u64!(
       segment._allocate_pointer(alloc_byte_size.u32)

--- a/src/CapnProto.Pointer.Struct.savi
+++ b/src/CapnProto.Pointer.Struct.savi
@@ -1,9 +1,9 @@
 :module _ParseStructPointer
-  :fun _parse!(segments, segment, current_offset U32, value U64)
+  :fun _parse!(segment CapnProto.Segment'box, current_offset U32, value U64)
     // Handle the case that this may be a far pointer, pointing to the pointer.
     override_byte_offset U32 = -1
     try (
-      far = _FarPointer._parse!(segments, current_offset, value)
+      far = _FarPointer._parse!(segment._segments, current_offset, value)
       segment = far._segment
       current_offset = far._byte_offset
       override_byte_offset = far._override_byte_offset
@@ -50,17 +50,16 @@
     pointer_count = value.bit_shr(48).u16
 
     CapnProto.Pointer.Struct._new(
-      segments, segment, byte_offset, data_word_count, pointer_count
+      segment, byte_offset, data_word_count, pointer_count
     )
 
-  :fun _parse_builder!(segments, segment, current_offset, value)
-    read_ptr = @_parse!(segments, segment, current_offset, value)
+  :fun _parse_builder!(segment CapnProto.Segment, current_offset, value)
+    read_ptr = @_parse!(segment, current_offset, value)
     if (read_ptr._segment !== segment) (
-      try (segment = segments._list[segment._index]!)
+      try (segment = segment._segments._list[read_ptr._segment._index]!)
     )
     CapnProto.Pointer.Struct.Builder._new(
-      segments, segment
-      read_ptr._byte_offset
+      segment, read_ptr._byte_offset
       read_ptr._data_word_count, read_ptr._pointer_count
     )
 
@@ -82,30 +81,19 @@
       .bit_or(pointer._pointer_count.u64.bit_shl(48)) // D (A and B are zero)
 
 :struct box CapnProto.Pointer.Struct
-  :let _segments CapnProto.Segments'box
   :let _segment CapnProto.Segment'box
   :let _byte_offset U32
   :let _data_word_count U16
   :let _pointer_count U16
   :new box _new(
-    @_segments, @_segment, @_byte_offset, @_data_word_count, @_pointer_count
+    @_segment, @_byte_offset
+    @_data_word_count, @_pointer_count
   )
 
-  :new box empty(@_segments, @_segment)
+  :new box empty(@_segment)
     @_byte_offset = 0
     @_data_word_count = 0
     @_pointer_count = 0
-
-  :fun non from_segments!(
-    segments CapnProto.Segments
-    start_offset USize = 0
-    segment_index USize = 0
-  )
-    segment = segments._list[segment_index]!
-    value = segment._u64!(start_offset.u32)
-    _ParseStructPointer._parse!(
-      segments, segment, start_offset.u32, value
-    )
 
   :fun _ptr_byte_offset!(n U16)
     error! unless (@_pointer_count > n)
@@ -148,70 +136,59 @@
   :fun text(n): try (@_text!(n) | @_empty_text)
   :fun _empty_text
     CapnProto.Text.read_from_pointer(
-      CapnProto.Pointer.U8List.empty(@_segments, @_segment)
+      CapnProto.Pointer.U8List.empty(@_segment)
     )
   :fun _text!(n)
     byte_offset = @_ptr_byte_offset!(n)
     CapnProto.Text.read_from_pointer(
       _ParseU8ListPointer._parse!(
-        @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+        @_segment, byte_offset, @_segment._u64!(byte_offset)
       )
     )
 
   :fun data(n): try (@_data!(n) | @_empty_data)
   :fun _empty_data
-    CapnProto.Data.from_pointer(CapnProto.Pointer.U8List.empty(@_segments, @_segment))
+    CapnProto.Data.from_pointer(CapnProto.Pointer.U8List.empty(@_segment))
   :fun _data!(n)
     byte_offset = @_ptr_byte_offset!(n)
     CapnProto.Data.read_from_pointer(
       _ParseU8ListPointer._parse!(
-        @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+        @_segment, byte_offset, @_segment._u64!(byte_offset)
       )
     )
 
   :fun struct(n): try (@_struct!(n) | @_empty_struct)
   :fun _empty_struct
-    CapnProto.Pointer.Struct.empty(@_segments, @_segment)
+    CapnProto.Pointer.Struct.empty(@_segment)
   :fun _struct!(n):
     byte_offset = @_ptr_byte_offset!(n)
     _ParseStructPointer._parse!(
-      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+      @_segment, byte_offset, @_segment._u64!(byte_offset)
     )
 
   :fun list(n): try (@_list!(n) | @_empty_list)
   :fun _empty_list
-    CapnProto.Pointer.StructList.empty(@_segments, @_segment)
+    CapnProto.Pointer.StructList.empty(@_segment)
   :fun _list!(n):
     byte_offset = @_ptr_byte_offset!(n)
     _ParseStructListPointer._parse!(
-      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+      @_segment, byte_offset, @_segment._u64!(byte_offset)
     )
 
 :struct CapnProto.Pointer.Struct.Builder
-  :let _segments CapnProto.Segments
   :let _segment CapnProto.Segment
   :let _byte_offset U32
   :let _data_word_count U16
   :let _pointer_count U16
   :new _new(
-    @_segments, @_segment, @_byte_offset, @_data_word_count, @_pointer_count
+    @_segment, @_byte_offset
+    @_data_word_count, @_pointer_count
   )
 
-  :new empty(@_segments, @_segment)
+  :new empty(@_segment)
     @_byte_offset = 0
     @_data_word_count = 0
     @_pointer_count = 0
-
-  :fun non from_segments!(
-    segments CapnProto.Segments
-    start_offset USize = 0
-    segment_index USize = 0
-  )
-    segment = segments._list[segment_index]!
-    value = segment._u64!(start_offset.u32)
-    _ParseStructPointer._parse!(
-      segments, segment, start_offset.u32, value
-    )
 
   :fun _ptr_byte_offset!(n U16)
     error! unless (@_pointer_count > n)
@@ -291,13 +268,13 @@
   :fun ref text(n): try (@_text!(n) | @_empty_text)
   :fun ref _empty_text
     CapnProto.Text.from_pointer(
-      CapnProto.Pointer.U8List.empty(@_segments, @_segment)
+      CapnProto.Pointer.U8List.empty(@_segment)
     )
   :fun ref _text!(n)
     byte_offset = @_ptr_byte_offset!(n)
     CapnProto.Text.from_pointer(
       _ParseU8ListPointer._parse_builder!(
-        @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+        @_segment, byte_offset, @_segment._u64!(byte_offset)
       )
     )
 
@@ -310,7 +287,7 @@
 
     // If there's an existing pointer, we can free it now.
     try _ParseU8ListPointer._parse_builder!(
-      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+      @_segment, byte_offset, @_segment._u64!(byte_offset)
     )._free(@_segment)
 
     // If the requested value is empty, we won't allocate anything new.
@@ -321,7 +298,7 @@
     )
 
     // Now we allocate the new one.
-    new_text = CapnProto.Text._new(@_segments, @_segment, value)
+    new_text = CapnProto.Text._new(@_segment, value)
 
     // We need to write the pointer to the buffer so it can be followed.
     try @_segment._set_u64!(
@@ -333,12 +310,12 @@
 
   :fun ref data(n): try (@_data!(n) | @_empty_data)
   :fun ref _empty_data
-    CapnProto.Data.from_pointer(CapnProto.Pointer.U8List.empty(@_segments, @_segment))
+    CapnProto.Data.from_pointer(CapnProto.Pointer.U8List.empty(@_segment))
   :fun ref _data!(n)
     byte_offset = @_ptr_byte_offset!(n)
     CapnProto.Data.from_pointer(
       _ParseU8ListPointer._parse_builder!(
-        @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+        @_segment, byte_offset, @_segment._u64!(byte_offset)
       )
     )
 
@@ -351,7 +328,7 @@
 
     // If there's an existing pointer, we can free it now.
     try _ParseU8ListPointer._parse_builder!(
-      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+      @_segment, byte_offset, @_segment._u64!(byte_offset)
     )._free(@_segment)
 
     // If the requested value is empty, we won't allocate anything new.
@@ -362,7 +339,7 @@
     )
 
     // Now we allocate the new one.
-    new_data = CapnProto.Data._new(@_segments, @_segment, value)
+    new_data = CapnProto.Data._new(@_segment, value)
 
     // We need to write the pointer to the buffer so it can be followed.
     try @_segment._set_u64!(
@@ -374,20 +351,20 @@
 
   :fun ref struct(n): try (@_struct!(n) | @_empty_struct)
   :fun ref _empty_struct
-    CapnProto.Pointer.Struct.Builder.empty(@_segments, @_segment)
+    CapnProto.Pointer.Struct.Builder.empty(@_segment)
   :fun ref _struct!(n):
     byte_offset = @_ptr_byte_offset!(n)
     _ParseStructPointer._parse_builder!(
-      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+      @_segment, byte_offset, @_segment._u64!(byte_offset)
     )
 
   :fun ref list(n): try (@_list!(n) | @_empty_list)
   :fun ref _empty_list
-    CapnProto.Pointer.StructList.Builder.empty(@_segments, @_segment)
+    CapnProto.Pointer.StructList.Builder.empty(@_segment)
   :fun ref _list!(n):
     byte_offset = @_ptr_byte_offset!(n)
     _ParseStructListPointer._parse_builder!(
-      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+      @_segment, byte_offset, @_segment._u64!(byte_offset)
     )
 
   :fun ref init_list(
@@ -402,7 +379,7 @@
 
     // If there's an existing list pointer, we can free it now.
     try _ParseStructListPointer._parse_builder!(
-      @_segments, @_segment, byte_offset, @_segment._u64!(byte_offset)
+      @_segment, byte_offset, @_segment._u64!(byte_offset)
     )._free
 
     // If the requested count is empty, we won't allocate anything new.
@@ -414,8 +391,7 @@
 
     // Now we allocate the new one.
     new_pointer = CapnProto.Pointer.StructList.Builder._allocate(
-      @_segments, @_segment
-      new_list_count, data_word_count, pointer_count
+      @_segment, new_list_count, data_word_count, pointer_count
     )
 
     // We need to write the pointer to the buffer so it can be followed.

--- a/src/CapnProto.Pointer.StructList.savi
+++ b/src/CapnProto.Pointer.StructList.savi
@@ -1,20 +1,9 @@
-:trait _ParsedStructListPointer
-  :new empty(segments CapnProto.Segments, segment CapnProto.Segment)
-  :new _new(
-    segments CapnProto.Segments
-    segment CapnProto.Segment
-    byte_offset U32
-    list_count U32
-    data_word_count U16
-    pointer_count U16
-  )
-
 :module _ParseStructListPointer
-  :fun non _parse!(segments, segment, current_offset U32, value U64)
+  :fun non _parse!(segment CapnProto.Segment'box, current_offset U32, value U64)
     // Handle the case that this may be a far pointer, pointing to the pointer.
     override_byte_offset U32 = -1
     try (
-      far = _FarPointer._parse!(segments, current_offset, value)
+      far = _FarPointer._parse!(segment._segments, current_offset, value)
       segment = far._segment
       current_offset = far._byte_offset
       override_byte_offset = far._override_byte_offset
@@ -81,7 +70,7 @@
     // which is distinct from the number of elements in the list.
     word_count = upper_32.bit_shr(3).usize
     if (word_count == 0) (
-      return CapnProto.Pointer.StructList.empty(segments, segment)
+      return CapnProto.Pointer.StructList.empty(segment)
     )
 
     // Read the tag pointer, which is similar to a struct pointer,
@@ -94,27 +83,21 @@
     pointer_count = tag_value.bit_shr(48).u16
 
     CapnProto.Pointer.StructList._new(
-      segments
-      segment
-      byte_offset
-      list_count
-      data_word_count
-      pointer_count
+      segment, byte_offset
+      list_count, data_word_count, pointer_count
     )
 
   :fun _parse_builder!(
-    segments CapnProto.Segments
     segment CapnProto.Segment
     current_offset, value
   )
-    read_ptr = @_parse!(segments, segment, current_offset, value)
+    read_ptr = @_parse!(segment, current_offset, value)
     if (read_ptr._segment !== segment) (
-      try (segment = segments._list[segment._index]!)
+      try (segment = segment._segments._list[read_ptr._segment._index]!)
     )
     CapnProto.Pointer.StructList.Builder._new(
-      segments, segment
-      read_ptr._byte_offset, read_ptr._list_count
-      read_ptr._data_word_count, read_ptr._pointer_count
+      segment, read_ptr._byte_offset
+      read_ptr._list_count, read_ptr._data_word_count, read_ptr._pointer_count
     )
 
 :module _WriteStructListPointer
@@ -158,22 +141,17 @@
       .bit_or(pointer._pointer_count.u64.bit_shl(48))      // D (A is zero)
 
 :struct box CapnProto.Pointer.StructList
-  :let _segments CapnProto.Segments'box
   :let _segment CapnProto.Segment'box
   :let _byte_offset U32
   :let _list_count U32
   :let _data_word_count U16
   :let _pointer_count U16
   :new box _new(
-    @_segments
-    @_segment
-    @_byte_offset
-    @_list_count
-    @_data_word_count
-    @_pointer_count
+    @_segment, @_byte_offset
+    @_list_count, @_data_word_count, @_pointer_count
   )
 
-  :new box empty(@_segments, @_segment)
+  :new box empty(@_segment)
     @_byte_offset = 0
     @_list_count = 0
     @_data_word_count = 0
@@ -181,24 +159,13 @@
 
   :fun _element_byte_size: (@_data_word_count.u32 + @_pointer_count.u32) * 8
 
-  :fun non from_segments!(
-    segments CapnProto.Segments
-    start_offset USize = 0
-    segment_index USize = 0
-  )
-    segment = segments._list[segment_index]!
-    value = segment._u64!(start_offset.u32)
-    _ParseStructListPointer._parse!(
-      segments, segment, start_offset.u32, value
-    )
-
   :fun "[]!"(n U32)
     error! unless (n < @_list_count)
 
     byte_offset = @_byte_offset +! @_element_byte_size *! n
 
     CapnProto.Pointer.Struct._new(
-      @_segments, @_segment, byte_offset, @_data_word_count, @_pointer_count
+      @_segment, byte_offset, @_data_word_count, @_pointer_count
     )
 
   :fun each
@@ -207,28 +174,23 @@
         byte_offset = @_byte_offset +! @_element_byte_size *! n
 
         yield CapnProto.Pointer.Struct._new(
-          @_segments, @_segment, byte_offset, @_data_word_count, @_pointer_count
+          @_segment, byte_offset, @_data_word_count, @_pointer_count
         )
       )
     )
 
 :struct CapnProto.Pointer.StructList.Builder
-  :let _segments CapnProto.Segments
   :let _segment CapnProto.Segment
   :let _byte_offset U32
   :let _list_count U32
   :let _data_word_count U16
   :let _pointer_count U16
   :new _new(
-    @_segments
-    @_segment
-    @_byte_offset
-    @_list_count
-    @_data_word_count
-    @_pointer_count
+    @_segment, @_byte_offset
+    @_list_count, @_data_word_count, @_pointer_count
   )
 
-  :new empty(@_segments, @_segment)
+  :new empty(@_segment)
     @_byte_offset = 0
     @_list_count = 0
     @_data_word_count = 0
@@ -241,7 +203,6 @@
   :fun ref _free: @_segment._free_pointer(@_byte_offset, @_total_byte_size), @
 
   :new _allocate(
-    @_segments
     @_segment
     @_list_count
     @_data_word_count
@@ -260,7 +221,6 @@
         ._reallocate_pointer(@_byte_offset, old_byte_size, new_byte_size)
 
       @_new(
-        @_segments
         @_segment
         new_byte_offset
         new_count
@@ -272,17 +232,6 @@
       @
     )
 
-  :fun non from_segments!(
-    segments CapnProto.Segments
-    start_offset USize = 0
-    segment_index USize = 0
-  )
-    segment = segments._list[segment_index]!
-    value = segment._u64!(start_offset.u32)
-    _ParseStructListPointer._parse_builder!(
-      segments, segment, start_offset.u32, value
-    )
-
   :fun ref "[]!"(n U32)
     error! unless (n < @_list_count)
 
@@ -290,7 +239,7 @@
       +! (@_data_word_count.u32 +! @_pointer_count.u32) *! n *! 8
 
     CapnProto.Pointer.Struct.Builder._new(
-      @_segments, @_segment, byte_offset, @_data_word_count, @_pointer_count
+      @_segment, byte_offset, @_data_word_count, @_pointer_count
     )
 
   :fun ref each
@@ -300,7 +249,7 @@
           +! (@_data_word_count.u32 +! @_pointer_count.u32) *! n *! 8
 
         yield CapnProto.Pointer.Struct.Builder._new(
-          @_segments, @_segment, byte_offset, @_data_word_count, @_pointer_count
+          @_segment, byte_offset, @_data_word_count, @_pointer_count
         )
       )
     )

--- a/src/CapnProto.Pointer.U8List.savi
+++ b/src/CapnProto.Pointer.U8List.savi
@@ -1,9 +1,9 @@
 :module _ParseU8ListPointer
-  :fun non _parse!(segments, segment, current_offset U32, value U64)
+  :fun non _parse!(segment CapnProto.Segment'box, current_offset U32, value U64)
     // Handle the case that this may be a far pointer, pointing to the pointer.
     override_byte_offset U32 = -1
     try (
-      far = _FarPointer._parse!(segments, current_offset, value)
+      far = _FarPointer._parse!(segment._segments, current_offset, value)
       segment = far._segment
       current_offset = far._byte_offset
       override_byte_offset = far._override_byte_offset
@@ -69,22 +69,15 @@
     // the number of bytes in the list, because this list is of the byte class.
     byte_count = upper_32.bit_shr(3).u32
 
-    CapnProto.Pointer.U8List._new_read(
-      segments, segment, byte_offset, byte_count
-    )
+    CapnProto.Pointer.U8List._new_read(segment, byte_offset, byte_count)
 
-  :fun _parse_builder!(
-    segments CapnProto.Segments
-    segment CapnProto.Segment
-    current_offset, value
-  )
-    read_ptr = @_parse!(segments, segment, current_offset, value)
+  :fun _parse_builder!(segment CapnProto.Segment, current_offset, value)
+    read_ptr = @_parse!(segment, current_offset, value)
     if (read_ptr._segment !== segment) (
-      try (segment = segments._list[segment._index]!)
+      try (segment = segment._segments._list[read_ptr._segment._index]!)
     )
     CapnProto.Pointer.U8List._new_read(
-      segments, segment
-      read_ptr._byte_offset, read_ptr._byte_count
+      segment, read_ptr._byte_offset, read_ptr._byte_count
     )
 
 :module _WriteU8ListPointer
@@ -121,13 +114,12 @@
       .bit_or(0x0000000200000001)                           // A and C
 
 :struct CapnProto.Pointer.U8List
-  :let _segments CapnProto.Segments'box
   :let _segment CapnProto.Segment'box
   :let _byte_offset U32
   :let _byte_count U32
-  :new box _new_read(@_segments, @_segment, @_byte_offset, @_byte_count)
+  :new box _new_read(@_segment, @_byte_offset, @_byte_count)
 
-  :new box empty(@_segments, @_segment)
+  :new box empty(@_segment)
     @_byte_offset = 0
     @_byte_count = 0
 
@@ -135,15 +127,6 @@
     if (segment === @_segment) (
       segment._free_pointer(@_byte_offset, @_byte_count), @
     )
-
-  :fun non from_segments!(
-    segments CapnProto.Segments
-    start_offset USize = 0
-    segment_index USize = 0
-  )
-    segment = segments._list[segment_index]!
-    value = segment._u64!(start_offset.u32)
-    _ParseU8ListPointer._parse!(segments, segment, start_offset.u32, value)
 
   :is Indexable(U8)
 

--- a/src/CapnProto.Text.savi
+++ b/src/CapnProto.Text.savi
@@ -3,10 +3,10 @@
   :new from_pointer(@_p)
   :new box read_from_pointer(p CapnProto.Pointer.U8List'box): @_p = p
 
-  :new _new(segments, segment CapnProto.Segment, value String)
+  :new _new(segment CapnProto.Segment, value String)
     byte_offset = segment._allocate_and_write_string(value)
     @_p = CapnProto.Pointer.U8List._new_read(
-      segments, segment, byte_offset, (value.size + 1).u32
+      segment, byte_offset, (value.size + 1).u32
     )
 
   :fun size: @_p._byte_count.usize.saturating_subtract(1) // trimming off the null terminator

--- a/src/capnpc-savi/Main.savi
+++ b/src/capnpc-savi/Main.savi
@@ -20,10 +20,9 @@
 
   :fun ref _handle_segments
     try (
-      segments = @_reader.take_segments
-      pointer = CapnProto.Pointer.Struct.from_segments!(segments)
-      req = CapnProto.Meta.CodeGeneratorRequest.read_from_pointer(pointer)
-      @_generate(req)
+      message = CapnProto.Message(CapnProto.Meta.CodeGeneratorRequest)
+        .from_segments!(@_reader.take_segments)
+      @_generate(message.root)
     |
       @env.err.print("Failed to parse the root of the capnpc data")
     )


### PR DESCRIPTION
Removed `CapnProto.Segments` arguments/fields in many places. The `CapnProto.Segment` class now contains a reference to the `CapnProto.Segments` list (which is only used in far pointers and thus is better tucked away instead of being carried everywhere as a separate struct field.

Removed `from_segments!` methods from each pointer type - these were only used in testing, and complicated things a bit.

Added `CapnProto.Message` with `from_segments!` function as the only official `from_segments!` method remaining.