### PR TITLE
Add method to get-or-allocate a child struct from a Builder.

### DIFF
--- a/spec/CapnProto.Message.Builder.Spec.savi
+++ b/spec/CapnProto.Message.Builder.Spec.savi
@@ -22,21 +22,23 @@
   :fun ref "some_u8="(new_value): @_p.set_u8(0x1e, new_value, 0)
   :fun ref "some_i8="(new_value): @_p.set_i8(0x1f, new_value, 0)
 
-  :const capn_proto_pointer_count U16: 4
+  :const capn_proto_pointer_count U16: 5
   :fun ref some_text: @_p.text(0)
   :fun ref some_data: @_p.data(1)
   :fun ref "some_text="(new_value): @_p.set_text(0, new_value, "")
   :fun ref "some_data="(new_value): @_p.set_data(1, new_value, b"")
 
-  :fun ref children: CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.list(2))
-  :fun ref init_children(new_count): CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.init_list(2, 2, 1, new_count))
+  :fun ref child: _ExampleChildBuilder.from_pointer(@_p.struct(2, 2, 1))
+
+  :fun ref children: CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.list(3))
+  :fun ref init_children(new_count): CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.init_list(3, 2, 1, new_count))
 
   :fun is_foo: @_p.check_union(0x30, 0)
   :fun ref foo!: @_p.assert_union!(0x30, 0), _ExampleAsFooBuilder.from_pointer(@_p)
   :fun ref init_foo
     @_p.clear_64(0x20)
     @_p.clear_32(0x28)
-    @_p.clear_pointer(3)
+    @_p.clear_pointer(4)
     @_p.mark_union(0x30, 0)
     _ExampleAsFooBuilder.from_pointer(@_p)
 
@@ -45,7 +47,7 @@
   :fun ref init_bar
     @_p.clear_64(0x20)
     @_p.clear_32(0x28)
-    @_p.clear_pointer(3)
+    @_p.clear_pointer(4)
     @_p.mark_union(0x30, 1)
     _ExampleAsBarBuilder.from_pointer(@_p)
 
@@ -73,9 +75,9 @@
   :fun ref "some_u64="(new_value): @_p.set_u64(0x20, new_value, 0)
   :fun ref "some_u32="(new_value): @_p.set_u32(0x28, new_value, 0)
 
-  :const capn_proto_pointer_count U16: 4
-  :fun ref txt: @_p.text(3)
-  :fun ref "txt="(new_value): @_p.set_text(3, new_value, "")
+  :const capn_proto_pointer_count U16: 5
+  :fun ref txt: @_p.text(4)
+  :fun ref "txt="(new_value): @_p.set_text(4, new_value, "")
 
 :struct _ExampleAsBarBuilder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -87,9 +89,9 @@
   :fun ref "some_f64="(new_value): @_p.set_f64(0x20, new_value, 0)
   :fun ref "some_f32="(new_value): @_p.set_f32(0x28, new_value, 0)
 
-  :const capn_proto_pointer_count U16: 4
-  :fun ref blob: @_p.data(3)
-  :fun ref "blob="(new_value): @_p.set_data(3, new_value, b"")
+  :const capn_proto_pointer_count U16: 5
+  :fun ref blob: @_p.data(4)
+  :fun ref "blob="(new_value): @_p.set_data(4, new_value, b"")
 
 :class CapnProto.Message.Builder.Spec
   :is Spec
@@ -122,6 +124,16 @@
     assert: "\(root.some_data)" == "This is some example data"
     root.some_data              = b""
     assert: "\(root.some_data)" == ""
+
+  :it "reads from and writes to fields of the child struct"
+    message = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
+    root = message.root
+    assert: root.child.a == 0, root.child.a = 77, assert: root.child.a == 77
+    assert: root.child.b == 0, root.child.b = 88, assert: root.child.b == 88
+
+    assert: "\(root.child.name)" == ""
+    root.child.name = "Alice"
+    assert: "\(root.child.name)" == "Alice"
 
   :it "reads from and writes to fields of the list children structs"
     message = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)

--- a/src/CapnProto.Meta.capnp.savi
+++ b/src/CapnProto.Meta.capnp.savi
@@ -733,9 +733,9 @@
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
 
-  :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(3))
+  :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(3, 3, 1))
 
-  :fun ref value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(4))
+  :fun ref value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(4, 2, 1))
 
 :struct CapnProto.Meta.Node.AS_annotation.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -744,7 +744,7 @@
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
 
-  :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(3))
+  :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(3, 3, 1))
 
   :fun targets_file: @_p.bool(0xe, 0b00000001)
   :fun ref "targets_file="(new_value): @_p.set_bool(0xe, 0b00000001, new_value)
@@ -855,9 +855,9 @@
   :fun offset: @_p.u32(0x4)
   :fun ref "offset="(new_value): @_p.set_u32(0x4, new_value, 0)
 
-  :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(2))
+  :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(2, 3, 1))
 
-  :fun ref default_value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(3))
+  :fun ref default_value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(3, 2, 1))
 
   :fun had_explicit_default: @_p.bool(0x10, 0b00000001)
   :fun ref "had_explicit_default="(new_value): @_p.set_bool(0x10, 0b00000001, new_value)
@@ -911,7 +911,7 @@
   :fun id: @_p.u64(0x0)
   :fun ref "id="(new_value): @_p.set_u64(0x0, new_value, 0)
 
-  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0))
+  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
 
 :struct CapnProto.Meta.Method.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -935,9 +935,9 @@
   :fun ref annotations: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list(1))
   :fun ref init_annotations(new_count): CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
 
-  :fun ref param_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(2))
+  :fun ref param_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(2, 0, 1))
 
-  :fun ref result_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(3))
+  :fun ref result_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(3, 0, 1))
 
   :fun ref implicit_parameters: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list(4))
   :fun ref init_implicit_parameters(new_count): CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.init_list(4, 0, 1, new_count))
@@ -1035,7 +1035,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
 
-  :fun ref element_type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(0))
+  :fun ref element_type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(0, 3, 1))
 
 :struct CapnProto.Meta.Type.AS_enum.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1047,7 +1047,7 @@
   :fun type_id: @_p.u64(0x8)
   :fun ref "type_id="(new_value): @_p.set_u64(0x8, new_value, 0)
 
-  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0))
+  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
 
 :struct CapnProto.Meta.Type.AS_struct.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1059,7 +1059,7 @@
   :fun type_id: @_p.u64(0x8)
   :fun ref "type_id="(new_value): @_p.set_u64(0x8, new_value, 0)
 
-  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0))
+  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
 
 :struct CapnProto.Meta.Type.AS_interface.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1071,7 +1071,7 @@
   :fun type_id: @_p.u64(0x8)
   :fun ref "type_id="(new_value): @_p.set_u64(0x8, new_value, 0)
 
-  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0))
+  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
 
 :struct CapnProto.Meta.Type.AS_anyPointer.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1184,7 +1184,7 @@
   :fun unbound!: @_p.assert_union!(0x0, 0), None
 
   :fun is_type: @_p.check_union(0x0, 1)
-  :fun ref type!: @_p.assert_union!(0x0, 1), CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(0))
+  :fun ref type!: @_p.assert_union!(0x0, 1), CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(0, 3, 1))
 
 :struct CapnProto.Meta.Value.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1260,9 +1260,9 @@
   :fun id: @_p.u64(0x0)
   :fun ref "id="(new_value): @_p.set_u64(0x0, new_value, 0)
 
-  :fun ref value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(0))
+  :fun ref value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(0, 2, 1))
 
-  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(1))
+  :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(1, 0, 1))
 
 :struct CapnProto.Meta.CodeGeneratorRequest.Builder
   :let _p CapnProto.Pointer.Struct.Builder

--- a/src/CapnProto.Pointer.Struct.savi
+++ b/src/CapnProto.Pointer.Struct.savi
@@ -1,5 +1,8 @@
 :module _ParseStructPointer
   :fun _parse!(segment CapnProto.Segment'box, current_offset U32, value U64)
+    // Quick error path for null pointers.
+    error! if value.is_zero
+
     // Handle the case that this may be a far pointer, pointing to the pointer.
     override_byte_offset U32 = -1
     try (
@@ -64,9 +67,7 @@
     )
 
 :module _WriteStructPointer
-  :fun _encode_with_zero_relative_offset(
-    pointer CapnProto.Pointer.Struct.Builder
-  )
+  :fun _encode(write_offset U32, pointer CapnProto.Pointer.Struct.Builder)
     // lsb                      struct pointer                       msb
     // +-+-----------------------------+---------------+---------------+
     // |A|             B               |       C       |       D       |
@@ -77,8 +78,18 @@
     //     start of the struct's data section.  Signed.
     // C (16 bits) = Size of the struct's data section, in words.
     // D (16 bits) = Size of the struct's pointer section, in words.
-    pointer._data_word_count.u64.bit_shl(32)           // C
-      .bit_or(pointer._pointer_count.u64.bit_shl(48)) // D (A and B are zero)
+
+    relative_words = (pointer._byte_offset / 8).i32 - (write_offset / 8).i32 - 1
+
+    relative_words.u64.bit_shl(2)                       // B (A is zero)
+      .bit_or(pointer._data_word_count.u64.bit_shl(32)) // C
+      .bit_or(pointer._pointer_count.u64.bit_shl(48))   // D
+
+  :fun _encode_with_zero_relative_offset(
+    pointer CapnProto.Pointer.Struct.Builder
+  )
+    pointer._data_word_count.u64.bit_shl(32)          // C (A and B are zero)
+      .bit_or(pointer._pointer_count.u64.bit_shl(48)) // D
 
 :struct box CapnProto.Pointer.Struct
   :let _segment CapnProto.Segment'box
@@ -189,6 +200,18 @@
     @_byte_offset = 0
     @_data_word_count = 0
     @_pointer_count = 0
+
+  :fun _total_byte_size: (@_data_word_count.u32 + @_pointer_count.u32) * 8
+
+  :new _allocate(
+    @_segment
+    @_data_word_count
+    @_pointer_count
+  )
+    byte_offset = @_segment._allocate_pointer(@_total_byte_size)
+    @_byte_offset = byte_offset
+
+  :fun ref _free: @_segment._free_pointer(@_byte_offset, @_total_byte_size), @
 
   :fun _ptr_byte_offset!(n U16)
     error! unless (@_pointer_count > n)
@@ -359,14 +382,38 @@
 
     new_data
 
-  :fun ref struct(n): try (@_struct!(n) | @_empty_struct)
   :fun ref _empty_struct
     CapnProto.Pointer.Struct.Builder.empty(@_segment)
-  :fun ref _struct!(n):
-    byte_offset = @_ptr_byte_offset!(n)
-    _ParseStructPointer._parse_builder!(
-      @_segment, byte_offset, @_segment._u64!(byte_offset)
+
+  :fun ref struct(
+    n U16
+    data_word_count U16
+    pointer_count U16
+  ) CapnProto.Pointer.Struct.Builder
+    // We expect the byte offset to be within bounds - otherwise we can't do it,
+    // and we'll return an empty struct to signal this problem.
+    byte_offset = try (@_ptr_byte_offset!(n) | return @_empty_struct)
+
+    // If there's an existing struct pointer, we can return it now.
+    try (
+      existing_pointer = _ParseStructPointer._parse_builder!(
+        @_segment, byte_offset, @_segment._u64!(byte_offset)
+      )
+      return existing_pointer
     )
+
+    // Otherwise we need to allocate a new one.
+    new_pointer = CapnProto.Pointer.Struct.Builder._allocate(
+      @_segment, data_word_count, pointer_count
+    )
+
+    // We need to write the pointer to the buffer so it can be followed.
+    try @_segment._set_u64!(
+      byte_offset
+      _WriteStructPointer._encode(byte_offset, new_pointer)
+    )
+
+    new_pointer
 
   :fun ref list(n): try (@_list!(n) | @_empty_list)
   :fun ref _empty_list
@@ -384,7 +431,7 @@
     new_list_count U32
   ) CapnProto.Pointer.StructList.Builder
     // We expect the byte offset to be within bounds - otherwise we can't do it,
-    // and we'll return an empty `CapnProto.Data` to signal this problem.
+    // and we'll return an empty list builder to signal this problem.
     byte_offset = try (@_ptr_byte_offset!(n) | return @_empty_list)
 
     // If there's an existing list pointer, we can free it now.

--- a/src/CapnProto.Pointer.StructList.savi
+++ b/src/CapnProto.Pointer.StructList.savi
@@ -1,5 +1,8 @@
 :module _ParseStructListPointer
   :fun non _parse!(segment CapnProto.Segment'box, current_offset U32, value U64)
+    // Quick error path for null pointers.
+    error! if value.is_zero
+
     // Handle the case that this may be a far pointer, pointing to the pointer.
     override_byte_offset U32 = -1
     try (

--- a/src/CapnProto.Pointer.U8List.savi
+++ b/src/CapnProto.Pointer.U8List.savi
@@ -1,5 +1,8 @@
 :module _ParseU8ListPointer
   :fun non _parse!(segment CapnProto.Segment'box, current_offset U32, value U64)
+    // Quick error path for null pointers.
+    error! if value.is_zero
+
     // Handle the case that this may be a far pointer, pointing to the pointer.
     override_byte_offset U32 = -1
     try (

--- a/src/CapnProto.Segment.savi
+++ b/src/CapnProto.Segment.savi
@@ -58,6 +58,9 @@
     new_offset
 
   :fun ref _allocate_pointer(need_size U32) U32
+    // TODO: Allocate an extra 8 bytes to use for reference counting,
+    // and then add incref and decref logic to allow sharing pointers.
+
     // Round up the requested size to the nearest multiple of 8.
     need_size = (need_size + 7).bit_and(-8)
 

--- a/src/capnpc-savi/_Gen.savi
+++ b/src/capnpc-savi/_Gen.savi
@@ -474,10 +474,16 @@
       )
       @_out << ")"
     | type.is_struct |
-      // TODO: handle default list values
-      @_out << "\(@_type_name(type, is_builder)).\(
-        if is_builder ("" | "read_")
-      )from_pointer(@_p.struct(\(offset)))"
+      // TODO: handle default struct values
+      try (
+        struct = @_find_node!(type.struct!.type_id).struct!
+
+        @_out << "\(@_type_name(type, is_builder)).\(
+          if is_builder ("" | "read_")
+        )from_pointer(@_p.struct(\(offset)\(
+          if is_builder ", \(struct.data_word_count), \(struct.pointer_count)"
+        )))"
+      )
     | type.is_interface |
       @_out << "None // UNHANDLED: interface" // TODO: handle interfaces
     | type.is_any_pointer |


### PR DESCRIPTION
This allows easy and effective lazy allocation of child structs when building up a message tree.