### PR TITLE
Fix `[]!` element access on lists to take type `USize` instead of `U32`.

### DIFF
--- a/src/CapnProto.List.savi
+++ b/src/CapnProto.List.savi
@@ -7,7 +7,7 @@
 
   :fun size: @_p._list_count.usize
 
-  :fun "[]!"(n): A.read_from_pointer(@_p[n]!)
+  :fun "[]!"(n USize): A.read_from_pointer(@_p[n.u32!]!)
 
   :fun each
     :yields A
@@ -22,7 +22,7 @@
 
   :fun size: @_p._list_count.usize
 
-  :fun ref "[]!"(n): A.from_pointer(@_p[n]!)
+  :fun ref "[]!"(n USize): A.from_pointer(@_p[n.u32!]!)
 
   :fun ref each
     :yields A


### PR DESCRIPTION
`USize` matches the `Indexable` trait, and is commonly used for collections. `U32` is just an internal CapnProto implementation detail.

I wanted to go ahead and try to use the `Indexable` trait itself here, but it's not ready for that until the language has cap specialization features that would let us implement `CapnProto.List.Builder` methods as `:fun` instead of `:fun ref`.