### PR TITLE
Add `CapnProto.Message.Builder.take_val_buffers`.

### DIFF
--- a/spec/CapnProto.Message.Builder.Spec.savi
+++ b/spec/CapnProto.Message.Builder.Spec.savi
@@ -194,3 +194,23 @@
     assert: bar.some_f64 == 0, bar.some_f64 = 42, assert: bar.some_f64 == 42
     assert: bar.some_f32 == 0, bar.some_f32 = 43, assert: bar.some_f32 == 43
     assert: "\(bar.blob)" == "", bar.blob = b"!!", assert: "\(bar.blob)" == "!!"
+
+  :it "lets you take the resulting byte buffers"
+    message = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
+    buffers = message.take_val_buffers
+
+    assert: buffers.size == 0
+
+    message.root.init_children(999) // allocate the root struct and 999 children
+
+    buffers = message.take_val_buffers
+    assert: buffers.size == 1
+    assert: buffers[0]!.size == 0x5E18
+    assert: buffers[0]!.space == 0x8000
+
+    message.root // allocate just the root struct
+
+    buffers = message.take_val_buffers
+    assert: buffers.size == 1
+    assert: buffers[0]!.size == 0x68
+    assert: buffers[0]!.space == 0x4000

--- a/src/CapnProto.Message.savi
+++ b/src/CapnProto.Message.savi
@@ -22,23 +22,32 @@
   :const capn_proto_pointer_count U16: 0
 
 :struct CapnProto.Message.Builder(A _MessageBuilderRoot)
-  :let root A
+  :let _initial_size USize
+  :let _segments CapnProto.Segments
 
   :new (initial_size USize)
     alloc_byte_size = (
       A.capn_proto_data_word_count.usize +
       A.capn_proto_pointer_count.usize
     ) * 8 + 8
-    initial_size = initial_size.at_least(alloc_byte_size)
+    @_initial_size = initial_size.at_least(alloc_byte_size)
+    @_segments = CapnProto.Segments.new
 
-    segments = CapnProto.Segments.new
-    segment = CapnProto.Segment.new(segments, initial_size)
+  :fun ref take_val_buffers: @_segments.take_val_buffers
+
+  :fun ref root
+    segment = try (
+      @_segments._list[0]!
+    |
+      CapnProto.Segment.new(@_segments, @_initial_size)
+    )
+
     pointer = CapnProto.Pointer.Struct.Builder._new(
       segment, 8, A.capn_proto_data_word_count, A.capn_proto_pointer_count
     )
     try segment._set_u64!(
-      segment._allocate_pointer(alloc_byte_size.u32)
+      segment._allocate_pointer(pointer._total_byte_size + 8)
       _WriteStructPointer._encode_with_zero_relative_offset(pointer)
     )
 
-    @root = A.from_pointer(pointer)
+    A.from_pointer(pointer)

--- a/src/CapnProto.Segment.savi
+++ b/src/CapnProto.Segment.savi
@@ -99,7 +99,8 @@
     // Expand the byte buffer to a size greater than or equal to the needed size
     // (in practice, the next power of 2 size, due to how `Bytes` works),
     // and fill the newly allocated bytes with zeros.
-    @_bytes.reserve(@_bytes.size + need_size.usize - final_hole_size.usize)
+    occupied_size = @_bytes.size + need_size.usize - final_hole_size.usize
+    @_bytes.reserve(occupied_size)
     @_bytes.fill_with_zeros(
       (final_hole_head + final_hole_size).usize
       @_bytes.space
@@ -107,8 +108,7 @@
 
     // Do the internal bookkeeping needed to ensure our remaining final hole
     // is properly accounted for, as necessary.
-    remaining_final_hole_size = @_bytes.space.u32 - @_bytes.size.u32
-    remaining_final_hole = Pair(U32).new(@_bytes.size.u32, @_bytes.space.u32)
+    remaining_final_hole = Pair(U32).new(occupied_size.u32, @_bytes.space.u32)
     if (remaining_final_hole.tail > remaining_final_hole.head) (
       if (final_hole_size > 0) (
         try (@_holes.last! = remaining_final_hole)
@@ -156,3 +156,11 @@
     // Otherwise, add it as a new hole at the end.
     @_holes << Pair(U32).new(free_head, free_tail)
     @
+
+  :fun ref _take_buffer Bytes'iso
+    buffer = @_bytes.take_buffer
+
+    try buffer.truncate(@_holes.last!.head.usize)
+    @_holes.clear
+
+    --buffer

--- a/src/CapnProto.Segments.savi
+++ b/src/CapnProto.Segments.savi
@@ -2,6 +2,12 @@
   :let _list Array(CapnProto.Segment)'ref
   :new: @_list = []
 
+  :fun ref take_val_buffers Array(Bytes)'val
+    out Array(Bytes)'iso = []
+    @_list.each -> (segment | out << segment._take_buffer)
+    @_list.clear
+    --out
+
 :class CapnProto.Segments.Reader
   :var _header: b""
   :var _segments: CapnProto.Segments.new // TODO: iso


### PR DESCRIPTION
This lets you extract the byte buffers once they've been built.