### PR TITLE
Add `CapnProto.Savi.Meta.namespace` annotation for `.capnp` files.

### DIFF
--- a/src/CapnProto.Meta.capnp
+++ b/src/CapnProto.Meta.capnp
@@ -21,6 +21,10 @@
 
 @0xa93fc509624c72d9;
 
+using Savi = import "CapnProto.Savi.Meta.capnp";
+$Savi.namespace("CapnProto.Meta");
+
+
 using Id = UInt64;
 # The globally-unique ID of a file, type, or annotation.
 

--- a/src/CapnProto.Savi.Meta.capnp
+++ b/src/CapnProto.Savi.Meta.capnp
@@ -1,0 +1,4 @@
+@0xbf772c07f494658e;
+$namespace("CapnProto.Savi.Meta");
+
+annotation namespace(file): Text;

--- a/src/capnpc-savi/Main.savi
+++ b/src/capnpc-savi/Main.savi
@@ -28,8 +28,10 @@
     )
 
   :fun ref _generate(req CapnProto.Meta.CodeGeneratorRequest)
-    req.nodes.each -> (node |
-      if node.is_file (
-        @env.out.print(_Gen.new(req, node).take_string)
+    req.requested_files.each -> (file |
+      req.nodes.each -> (node |
+        if (node.id == file.id) (
+          @env.out.print(_Gen.new(req, node).take_string)
+        )
       )
     )

--- a/src/capnpc-savi/_Gen.savi
+++ b/src/capnpc-savi/_Gen.savi
@@ -23,7 +23,14 @@
     try (
       case (
       | node.is_file |
-        "CapnProto.Meta" // TODO: not hard-coded here
+        node.annotations.each -> (annotation |
+          // The namespace of the file can be dictated by the `namespace`
+          // annotation in `CapnProto.Savi.Meta.capnp`, whose id is well-known.
+          if (annotation.id == 0x9c3f4a6aa35d6820) (
+            return "\(try annotation.value.text!)"
+          )
+        )
+        "_"
       | node.is_struct && node.struct!.is_group |
         @_node_scoped_name_of_group!(node)
       |
@@ -46,9 +53,14 @@
 
   :fun _node_scoped_name_of_typedecl!(node CapnProto.Meta.Node) String
     scope_node = @_find_node!(node.scope_id)
+    scope_node_name = @_node_scoped_name(scope_node)
     scope_node.nested_nodes.each -> (nested |
       if (nested.id == node.id) (
-        return "\(@_node_scoped_name(scope_node)).\(nested.name)"
+        if (scope_node_name == "_") (
+          return "_\(nested.name)"
+        |
+          return "\(scope_node_name).\(nested.name)"
+        )
       )
     )
     error!


### PR DESCRIPTION
This will allow the file to specify what the Savi namespace of the generated code should be, similar to the equivalent annotation that exists in the standard `c++.capnp` file.