### PR TITLE
Add `*_if_set!` getter variants, which raise an error if not set.

### DIFF
--- a/spec/CapnProto.Message.Builder.Spec.savi
+++ b/spec/CapnProto.Message.Builder.Spec.savi
@@ -13,6 +13,14 @@
   :fun some_i16: @_p.i16(0x1c)
   :fun some_u8: @_p.u8(0x1e)
   :fun some_i8: @_p.i8(0x1f)
+  :fun some_u64_if_set!: @_p.u64_if_set!(0x0)
+  :fun some_i64_if_set!: @_p.i64_if_set!(0x8)
+  :fun some_u32_if_set!: @_p.u32_if_set!(0x10)
+  :fun some_i32_if_set!: @_p.i32_if_set!(0x14)
+  :fun some_u16_if_set!: @_p.u16_if_set!(0x18)
+  :fun some_i16_if_set!: @_p.i16_if_set!(0x1c)
+  :fun some_u8_if_set!: @_p.u8_if_set!(0x1e)
+  :fun some_i8_if_set!: @_p.i8_if_set!(0x1f)
   :fun ref "some_u64="(new_value): @_p.set_u64(0x0, new_value, 0)
   :fun ref "some_i64="(new_value): @_p.set_i64(0x8, new_value, 0)
   :fun ref "some_u32="(new_value): @_p.set_u32(0x10, new_value, 0)
@@ -25,12 +33,16 @@
   :const capn_proto_pointer_count U16: 5
   :fun ref some_text: @_p.text(0)
   :fun ref some_data: @_p.data(1)
+  :fun ref some_text_if_set!: @_p.text_if_set!(0)
+  :fun ref some_data_if_set!: @_p.data_if_set!(1)
   :fun ref "some_text="(new_value): @_p.set_text(0, new_value, "")
   :fun ref "some_data="(new_value): @_p.set_data(1, new_value, b"")
 
   :fun ref child: _ExampleChildBuilder.from_pointer(@_p.struct(2, 2, 1))
+  :fun ref child_if_set!: _ExampleChildBuilder.from_pointer(@_p.struct_if_set!(2, 2, 1))
 
   :fun ref children: CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.list(3))
+  :fun ref children_if_set!: CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.list_if_set!(3))
   :fun ref init_children(new_count): CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.init_list(3, 2, 1, new_count))
 
   :fun is_foo: @_p.check_union(0x30, 0)
@@ -109,40 +121,52 @@
     assert: root.some_u8  == 0, root.some_u8  = 41, assert: root.some_u8  == 41
     assert: root.some_i8  == 0, root.some_i8  = 42, assert: root.some_i8  == 42
 
-    assert: "\(root.some_text)" == ""
-    root.some_text               = "foo"
-    assert: "\(root.some_text)" == "foo"
-    root.some_text               = "This is an example string"
-    assert: "\(root.some_text)" == "This is an example string"
-    root.some_text               = ""
-    assert: "\(root.some_text)" == ""
+    assert error: root.some_text_if_set!
+    assert: "\(root.some_text)"         == ""
+    root.some_text                       = "foo"
+    assert: "\(root.some_text)"         == "foo"
+    assert: "\(root.some_text_if_set!)" == "foo"
+    root.some_text                       = "This is an example string"
+    assert: "\(root.some_text)"         == "This is an example string"
+    assert: "\(root.some_text_if_set!)" == "This is an example string"
+    root.some_text                       = ""
+    assert: "\(root.some_text)"         == ""
+    assert error: root.some_text_if_set!
 
-    assert: "\(root.some_data)" == ""
-    root.some_data              = b"bar"
-    assert: "\(root.some_data)" == "bar"
-    root.some_data              = b"This is some example data"
-    assert: "\(root.some_data)" == "This is some example data"
-    root.some_data              = b""
-    assert: "\(root.some_data)" == ""
+    assert error: root.some_data_if_set!
+    assert: "\(root.some_data)"         == ""
+    root.some_data                      = b"bar"
+    assert: "\(root.some_data)"         == "bar"
+    assert: "\(root.some_data_if_set!)" == "bar"
+    root.some_data                      = b"This is some example data"
+    assert: "\(root.some_data)"         == "This is some example data"
+    assert: "\(root.some_data_if_set!)" == "This is some example data"
+    root.some_data                      = b""
+    assert: "\(root.some_data)"         == ""
+    assert error: root.some_data_if_set!
 
   :it "reads from and writes to fields of the child struct"
     message = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
     root = message.root
+    assert error: root.child_if_set!
     assert: root.child.a == 0, root.child.a = 77, assert: root.child.a == 77
     assert: root.child.b == 0, root.child.b = 88, assert: root.child.b == 88
 
     assert: "\(root.child.name)" == ""
     root.child.name = "Alice"
     assert: "\(root.child.name)" == "Alice"
+    assert: "\(root.child_if_set!.name)" == "Alice"
 
   :it "reads from and writes to fields of the list children structs"
     message = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
     root = message.root
 
     assert: root.children.size == 0
+    assert error: root.children_if_set!
     assert error: root.children[0]!
 
     assert: root.init_children(3).size == 3
+    assert: root.children_if_set!.size == 3
     assert: root.children[0]!.a == 0
     assert: root.children[0]!.b == 0
     assert: "\(root.children[0]!.name)" == ""

--- a/spec/CapnProto.Pointer.Struct.Builder.Spec.savi
+++ b/spec/CapnProto.Pointer.Struct.Builder.Spec.savi
@@ -13,10 +13,14 @@
   :it "writes and reads numeric values in the data region"
     p = @init_with_size(0x10, 0)
 
+    assert error: p.u64_if_set!(0x0) // not yet set
+    assert error: p.u64_if_set!(0x8) // not yet set
     assert: p.set_u64(0x0, 0xbeeedeeed000daaa, 0) == 0xbeeedeeed000daaa
     assert: p.set_u64(0x8, 0xb333d333d0ffdaff, 0) == 0xb333d333d0ffdaff
     assert: p.u64(0x0) == 0xbeeedeeed000daaa
     assert: p.u64(0x8) == 0xb333d333d0ffdaff
+    assert: p.u64_if_set!(0x0) == 0xbeeedeeed000daaa
+    assert: p.u64_if_set!(0x8) == 0xb333d333d0ffdaff
 
     assert: p.set_u32(0x0, 0xbaaafaaa, 0) == 0xbaaafaaa
     assert: p.set_u32(0x4, 0xb000f000, 0) == 0xb000f000

--- a/spec/CapnProto.Pointer.Struct.Spec.savi
+++ b/spec/CapnProto.Pointer.Struct.Spec.savi
@@ -65,6 +65,19 @@
     assert no_error: p.assert_union!(0x2, 0x3322)
     assert    error: p.assert_union!(0x2, 0x3300)
 
+    assert: p.u64_if_set!(0x8) == 0xffeeddccbbaa9988
+    assert error: p.u64_if_set!(0x10) // outside the data region
+    assert: p.u32_if_set!(0xc) == 0xffeeddcc
+    assert error: p.u32_if_set!(0x10) // outside the data region
+    assert: p.u16_if_set!(0xe) == 0xffee
+    assert error: p.u16_if_set!(0x10) == 0 // outside the data region
+    assert: p.u8_if_set!(0xf) == 0xff
+    assert error: p.u8_if_set!(0x10) // outside the data region
+    assert error: p.u8_if_set!(0x0) // inside the data region, but zero
+    assert: p.bool_if_set!(0xf, 0b10).is_true
+    assert error: p.bool_if_set!(0x10, 0b1) // outside the data region
+    assert error: p.bool_if_set!(0x0, 0b1) // inside the data region, but false
+
   :it "can point to a prior data region"
     p = @from_segment(b"\
       \x00\x11\x22\x33\x44\x55\x66\x77\

--- a/src/CapnProto.Meta.capnp.savi
+++ b/src/CapnProto.Meta.capnp.savi
@@ -10,38 +10,52 @@
   :const capn_proto_pointer_count U16: 6
 
   :fun id: @_p.u64(0x0)
+  :fun id_if_set!: @_p.u64_if_set!(0x0)
 
   :fun display_name: @_p.text(0)
+  :fun display_name_if_set!: @_p.text_if_set!(0)
 
   :fun display_name_prefix_length: @_p.u32(0x8)
+  :fun display_name_prefix_length_if_set!: @_p.u32_if_set!(0x8)
 
   :fun scope_id: @_p.u64(0x10)
+  :fun scope_id_if_set!: @_p.u64_if_set!(0x10)
 
   :fun nested_nodes: CapnProto.List(CapnProto.Meta.Node.NestedNode).read_from_pointer(@_p.list(1))
+  :fun nested_nodes_if_set!: CapnProto.List(CapnProto.Meta.Node.NestedNode).read_from_pointer(@_p.list_if_set!(1))
 
   :fun annotations: CapnProto.List(CapnProto.Meta.Annotation).read_from_pointer(@_p.list(2))
+  :fun annotations_if_set!: CapnProto.List(CapnProto.Meta.Annotation).read_from_pointer(@_p.list_if_set!(2))
 
   :fun is_file: @_p.check_union(0xc, 0)
   :fun file!: @_p.assert_union!(0xc, 0), None
+  :fun file_if_set!: @_p.assert_union!(0xc, 0), None
 
   :fun is_struct: @_p.check_union(0xc, 1)
   :fun struct!: @_p.assert_union!(0xc, 1), CapnProto.Meta.Node.AS_struct.read_from_pointer(@_p)
+  :fun struct_if_set!: @_p.assert_union!(0xc, 1), CapnProto.Meta.Node.AS_struct.read_from_pointer(@_p)
 
   :fun is_enum: @_p.check_union(0xc, 2)
   :fun enum!: @_p.assert_union!(0xc, 2), CapnProto.Meta.Node.AS_enum.read_from_pointer(@_p)
+  :fun enum_if_set!: @_p.assert_union!(0xc, 2), CapnProto.Meta.Node.AS_enum.read_from_pointer(@_p)
 
   :fun is_interface: @_p.check_union(0xc, 3)
   :fun interface!: @_p.assert_union!(0xc, 3), CapnProto.Meta.Node.AS_interface.read_from_pointer(@_p)
+  :fun interface_if_set!: @_p.assert_union!(0xc, 3), CapnProto.Meta.Node.AS_interface.read_from_pointer(@_p)
 
   :fun is_const: @_p.check_union(0xc, 4)
   :fun const!: @_p.assert_union!(0xc, 4), CapnProto.Meta.Node.AS_const.read_from_pointer(@_p)
+  :fun const_if_set!: @_p.assert_union!(0xc, 4), CapnProto.Meta.Node.AS_const.read_from_pointer(@_p)
 
   :fun is_annotation: @_p.check_union(0xc, 5)
   :fun annotation!: @_p.assert_union!(0xc, 5), CapnProto.Meta.Node.AS_annotation.read_from_pointer(@_p)
+  :fun annotation_if_set!: @_p.assert_union!(0xc, 5), CapnProto.Meta.Node.AS_annotation.read_from_pointer(@_p)
 
   :fun parameters: CapnProto.List(CapnProto.Meta.Node.Parameter).read_from_pointer(@_p.list(5))
+  :fun parameters_if_set!: CapnProto.List(CapnProto.Meta.Node.Parameter).read_from_pointer(@_p.list_if_set!(5))
 
   :fun is_generic: @_p.bool(0x24, 0b00000001)
+  :fun is_generic_if_set!: @_p.bool_if_set!(0x24, 0b00000001)
 
 :struct box CapnProto.Meta.Node.AS_struct
   :let _p CapnProto.Pointer.Struct
@@ -51,18 +65,25 @@
   :const capn_proto_pointer_count U16: 6
 
   :fun data_word_count: @_p.u16(0xe)
+  :fun data_word_count_if_set!: @_p.u16_if_set!(0xe)
 
   :fun pointer_count: @_p.u16(0x18)
+  :fun pointer_count_if_set!: @_p.u16_if_set!(0x18)
 
   :fun preferred_list_encoding: CapnProto.Meta.ElementSize._new(@_p.u16(0x1a))
+  :fun preferred_list_encoding_if_set!: CapnProto.Meta.ElementSize._new(@_p.u16_if_set!(0x1a))
 
   :fun is_group: @_p.bool(0x1c, 0b00000001)
+  :fun is_group_if_set!: @_p.bool_if_set!(0x1c, 0b00000001)
 
   :fun discriminant_count: @_p.u16(0x1e)
+  :fun discriminant_count_if_set!: @_p.u16_if_set!(0x1e)
 
   :fun discriminant_offset: @_p.u32(0x20)
+  :fun discriminant_offset_if_set!: @_p.u32_if_set!(0x20)
 
   :fun fields: CapnProto.List(CapnProto.Meta.Field).read_from_pointer(@_p.list(3))
+  :fun fields_if_set!: CapnProto.List(CapnProto.Meta.Field).read_from_pointer(@_p.list_if_set!(3))
 
 :struct box CapnProto.Meta.Node.AS_enum
   :let _p CapnProto.Pointer.Struct
@@ -72,6 +93,7 @@
   :const capn_proto_pointer_count U16: 6
 
   :fun enumerants: CapnProto.List(CapnProto.Meta.Enumerant).read_from_pointer(@_p.list(3))
+  :fun enumerants_if_set!: CapnProto.List(CapnProto.Meta.Enumerant).read_from_pointer(@_p.list_if_set!(3))
 
 :struct box CapnProto.Meta.Node.AS_interface
   :let _p CapnProto.Pointer.Struct
@@ -81,8 +103,10 @@
   :const capn_proto_pointer_count U16: 6
 
   :fun methods: CapnProto.List(CapnProto.Meta.Method).read_from_pointer(@_p.list(3))
+  :fun methods_if_set!: CapnProto.List(CapnProto.Meta.Method).read_from_pointer(@_p.list_if_set!(3))
 
   :fun superclasses: CapnProto.List(CapnProto.Meta.Superclass).read_from_pointer(@_p.list(4))
+  :fun superclasses_if_set!: CapnProto.List(CapnProto.Meta.Superclass).read_from_pointer(@_p.list_if_set!(4))
 
 :struct box CapnProto.Meta.Node.AS_const
   :let _p CapnProto.Pointer.Struct
@@ -92,8 +116,10 @@
   :const capn_proto_pointer_count U16: 6
 
   :fun type: CapnProto.Meta.Type.read_from_pointer(@_p.struct(3))
+  :fun type_if_set!: CapnProto.Meta.Type.read_from_pointer(@_p.struct_if_set!(3))
 
   :fun value: CapnProto.Meta.Value.read_from_pointer(@_p.struct(4))
+  :fun value_if_set!: CapnProto.Meta.Value.read_from_pointer(@_p.struct_if_set!(4))
 
 :struct box CapnProto.Meta.Node.AS_annotation
   :let _p CapnProto.Pointer.Struct
@@ -103,30 +129,43 @@
   :const capn_proto_pointer_count U16: 6
 
   :fun type: CapnProto.Meta.Type.read_from_pointer(@_p.struct(3))
+  :fun type_if_set!: CapnProto.Meta.Type.read_from_pointer(@_p.struct_if_set!(3))
 
   :fun targets_file: @_p.bool(0xe, 0b00000001)
+  :fun targets_file_if_set!: @_p.bool_if_set!(0xe, 0b00000001)
 
   :fun targets_const: @_p.bool(0xe, 0b00000010)
+  :fun targets_const_if_set!: @_p.bool_if_set!(0xe, 0b00000010)
 
   :fun targets_enum: @_p.bool(0xe, 0b00000100)
+  :fun targets_enum_if_set!: @_p.bool_if_set!(0xe, 0b00000100)
 
   :fun targets_enumerant: @_p.bool(0xe, 0b00001000)
+  :fun targets_enumerant_if_set!: @_p.bool_if_set!(0xe, 0b00001000)
 
   :fun targets_struct: @_p.bool(0xe, 0b00010000)
+  :fun targets_struct_if_set!: @_p.bool_if_set!(0xe, 0b00010000)
 
   :fun targets_field: @_p.bool(0xe, 0b00100000)
+  :fun targets_field_if_set!: @_p.bool_if_set!(0xe, 0b00100000)
 
   :fun targets_union: @_p.bool(0xe, 0b01000000)
+  :fun targets_union_if_set!: @_p.bool_if_set!(0xe, 0b01000000)
 
   :fun targets_group: @_p.bool(0xe, 0b10000000)
+  :fun targets_group_if_set!: @_p.bool_if_set!(0xe, 0b10000000)
 
   :fun targets_interface: @_p.bool(0xf, 0b00000001)
+  :fun targets_interface_if_set!: @_p.bool_if_set!(0xf, 0b00000001)
 
   :fun targets_method: @_p.bool(0xf, 0b00000010)
+  :fun targets_method_if_set!: @_p.bool_if_set!(0xf, 0b00000010)
 
   :fun targets_param: @_p.bool(0xf, 0b00000100)
+  :fun targets_param_if_set!: @_p.bool_if_set!(0xf, 0b00000100)
 
   :fun targets_annotation: @_p.bool(0xf, 0b00001000)
+  :fun targets_annotation_if_set!: @_p.bool_if_set!(0xf, 0b00001000)
 
 :struct box CapnProto.Meta.Node.Parameter
   :let _p CapnProto.Pointer.Struct
@@ -136,6 +175,7 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun name: @_p.text(0)
+  :fun name_if_set!: @_p.text_if_set!(0)
 
 :struct box CapnProto.Meta.Node.NestedNode
   :let _p CapnProto.Pointer.Struct
@@ -145,8 +185,10 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun name: @_p.text(0)
+  :fun name_if_set!: @_p.text_if_set!(0)
 
   :fun id: @_p.u64(0x0)
+  :fun id_if_set!: @_p.u64_if_set!(0x0)
 
 :struct box CapnProto.Meta.Field
   :let _p CapnProto.Pointer.Struct
@@ -158,20 +200,27 @@
   :const no_discriminant U16: 65535
 
   :fun name: @_p.text(0)
+  :fun name_if_set!: @_p.text_if_set!(0)
 
   :fun code_order: @_p.u16(0x0)
+  :fun code_order_if_set!: @_p.u16_if_set!(0x0)
 
   :fun annotations: CapnProto.List(CapnProto.Meta.Annotation).read_from_pointer(@_p.list(1))
+  :fun annotations_if_set!: CapnProto.List(CapnProto.Meta.Annotation).read_from_pointer(@_p.list_if_set!(1))
 
   :fun discriminant_value: @_p.u16(0x2).bit_xor(65535)
+  :fun discriminant_value_if_set!: @_p.u16_if_set!(0x2).bit_xor(65535)
 
   :fun is_slot: @_p.check_union(0x8, 0)
   :fun slot!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Field.AS_slot.read_from_pointer(@_p)
+  :fun slot_if_set!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Field.AS_slot.read_from_pointer(@_p)
 
   :fun is_group: @_p.check_union(0x8, 1)
   :fun group!: @_p.assert_union!(0x8, 1), CapnProto.Meta.Field.AS_group.read_from_pointer(@_p)
+  :fun group_if_set!: @_p.assert_union!(0x8, 1), CapnProto.Meta.Field.AS_group.read_from_pointer(@_p)
 
   :fun ordinal: CapnProto.Meta.Field.AS_ordinal.read_from_pointer(@_p)
+  :fun ordinal_if_set!: CapnProto.Meta.Field.AS_ordinal.read_from_pointer(@_p)
 
 :struct box CapnProto.Meta.Field.AS_slot
   :let _p CapnProto.Pointer.Struct
@@ -181,12 +230,16 @@
   :const capn_proto_pointer_count U16: 4
 
   :fun offset: @_p.u32(0x4)
+  :fun offset_if_set!: @_p.u32_if_set!(0x4)
 
   :fun type: CapnProto.Meta.Type.read_from_pointer(@_p.struct(2))
+  :fun type_if_set!: CapnProto.Meta.Type.read_from_pointer(@_p.struct_if_set!(2))
 
   :fun default_value: CapnProto.Meta.Value.read_from_pointer(@_p.struct(3))
+  :fun default_value_if_set!: CapnProto.Meta.Value.read_from_pointer(@_p.struct_if_set!(3))
 
   :fun had_explicit_default: @_p.bool(0x10, 0b00000001)
+  :fun had_explicit_default_if_set!: @_p.bool_if_set!(0x10, 0b00000001)
 
 :struct box CapnProto.Meta.Field.AS_group
   :let _p CapnProto.Pointer.Struct
@@ -196,6 +249,7 @@
   :const capn_proto_pointer_count U16: 4
 
   :fun type_id: @_p.u64(0x10)
+  :fun type_id_if_set!: @_p.u64_if_set!(0x10)
 
 :struct box CapnProto.Meta.Field.AS_ordinal
   :let _p CapnProto.Pointer.Struct
@@ -206,9 +260,11 @@
 
   :fun is_implicit: @_p.check_union(0xa, 0)
   :fun implicit!: @_p.assert_union!(0xa, 0), None
+  :fun implicit_if_set!: @_p.assert_union!(0xa, 0), None
 
   :fun is_explicit: @_p.check_union(0xa, 1)
   :fun explicit!: @_p.assert_union!(0xa, 1), @_p.u16(0xc)
+  :fun explicit_if_set!: @_p.assert_union!(0xa, 1), @_p.u16_if_set!(0xc)
 
 :struct box CapnProto.Meta.Enumerant
   :let _p CapnProto.Pointer.Struct
@@ -218,10 +274,13 @@
   :const capn_proto_pointer_count U16: 2
 
   :fun name: @_p.text(0)
+  :fun name_if_set!: @_p.text_if_set!(0)
 
   :fun code_order: @_p.u16(0x0)
+  :fun code_order_if_set!: @_p.u16_if_set!(0x0)
 
   :fun annotations: CapnProto.List(CapnProto.Meta.Annotation).read_from_pointer(@_p.list(1))
+  :fun annotations_if_set!: CapnProto.List(CapnProto.Meta.Annotation).read_from_pointer(@_p.list_if_set!(1))
 
 :struct box CapnProto.Meta.Superclass
   :let _p CapnProto.Pointer.Struct
@@ -231,8 +290,10 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun id: @_p.u64(0x0)
+  :fun id_if_set!: @_p.u64_if_set!(0x0)
 
   :fun brand: CapnProto.Meta.Brand.read_from_pointer(@_p.struct(0))
+  :fun brand_if_set!: CapnProto.Meta.Brand.read_from_pointer(@_p.struct_if_set!(0))
 
 :struct box CapnProto.Meta.Method
   :let _p CapnProto.Pointer.Struct
@@ -242,20 +303,28 @@
   :const capn_proto_pointer_count U16: 5
 
   :fun name: @_p.text(0)
+  :fun name_if_set!: @_p.text_if_set!(0)
 
   :fun code_order: @_p.u16(0x0)
+  :fun code_order_if_set!: @_p.u16_if_set!(0x0)
 
   :fun param_struct_type: @_p.u64(0x8)
+  :fun param_struct_type_if_set!: @_p.u64_if_set!(0x8)
 
   :fun result_struct_type: @_p.u64(0x10)
+  :fun result_struct_type_if_set!: @_p.u64_if_set!(0x10)
 
   :fun annotations: CapnProto.List(CapnProto.Meta.Annotation).read_from_pointer(@_p.list(1))
+  :fun annotations_if_set!: CapnProto.List(CapnProto.Meta.Annotation).read_from_pointer(@_p.list_if_set!(1))
 
   :fun param_brand: CapnProto.Meta.Brand.read_from_pointer(@_p.struct(2))
+  :fun param_brand_if_set!: CapnProto.Meta.Brand.read_from_pointer(@_p.struct_if_set!(2))
 
   :fun result_brand: CapnProto.Meta.Brand.read_from_pointer(@_p.struct(3))
+  :fun result_brand_if_set!: CapnProto.Meta.Brand.read_from_pointer(@_p.struct_if_set!(3))
 
   :fun implicit_parameters: CapnProto.List(CapnProto.Meta.Node.Parameter).read_from_pointer(@_p.list(4))
+  :fun implicit_parameters_if_set!: CapnProto.List(CapnProto.Meta.Node.Parameter).read_from_pointer(@_p.list_if_set!(4))
 
 :struct box CapnProto.Meta.Type
   :let _p CapnProto.Pointer.Struct
@@ -266,60 +335,79 @@
 
   :fun is_void: @_p.check_union(0x0, 0)
   :fun void!: @_p.assert_union!(0x0, 0), None
+  :fun void_if_set!: @_p.assert_union!(0x0, 0), None
 
   :fun is_bool: @_p.check_union(0x0, 1)
   :fun bool!: @_p.assert_union!(0x0, 1), None
+  :fun bool_if_set!: @_p.assert_union!(0x0, 1), None
 
   :fun is_int8: @_p.check_union(0x0, 2)
   :fun int8!: @_p.assert_union!(0x0, 2), None
+  :fun int8_if_set!: @_p.assert_union!(0x0, 2), None
 
   :fun is_int16: @_p.check_union(0x0, 3)
   :fun int16!: @_p.assert_union!(0x0, 3), None
+  :fun int16_if_set!: @_p.assert_union!(0x0, 3), None
 
   :fun is_int32: @_p.check_union(0x0, 4)
   :fun int32!: @_p.assert_union!(0x0, 4), None
+  :fun int32_if_set!: @_p.assert_union!(0x0, 4), None
 
   :fun is_int64: @_p.check_union(0x0, 5)
   :fun int64!: @_p.assert_union!(0x0, 5), None
+  :fun int64_if_set!: @_p.assert_union!(0x0, 5), None
 
   :fun is_uint8: @_p.check_union(0x0, 6)
   :fun uint8!: @_p.assert_union!(0x0, 6), None
+  :fun uint8_if_set!: @_p.assert_union!(0x0, 6), None
 
   :fun is_uint16: @_p.check_union(0x0, 7)
   :fun uint16!: @_p.assert_union!(0x0, 7), None
+  :fun uint16_if_set!: @_p.assert_union!(0x0, 7), None
 
   :fun is_uint32: @_p.check_union(0x0, 8)
   :fun uint32!: @_p.assert_union!(0x0, 8), None
+  :fun uint32_if_set!: @_p.assert_union!(0x0, 8), None
 
   :fun is_uint64: @_p.check_union(0x0, 9)
   :fun uint64!: @_p.assert_union!(0x0, 9), None
+  :fun uint64_if_set!: @_p.assert_union!(0x0, 9), None
 
   :fun is_float32: @_p.check_union(0x0, 10)
   :fun float32!: @_p.assert_union!(0x0, 10), None
+  :fun float32_if_set!: @_p.assert_union!(0x0, 10), None
 
   :fun is_float64: @_p.check_union(0x0, 11)
   :fun float64!: @_p.assert_union!(0x0, 11), None
+  :fun float64_if_set!: @_p.assert_union!(0x0, 11), None
 
   :fun is_text: @_p.check_union(0x0, 12)
   :fun text!: @_p.assert_union!(0x0, 12), None
+  :fun text_if_set!: @_p.assert_union!(0x0, 12), None
 
   :fun is_data: @_p.check_union(0x0, 13)
   :fun data!: @_p.assert_union!(0x0, 13), None
+  :fun data_if_set!: @_p.assert_union!(0x0, 13), None
 
   :fun is_list: @_p.check_union(0x0, 14)
   :fun list!: @_p.assert_union!(0x0, 14), CapnProto.Meta.Type.AS_list.read_from_pointer(@_p)
+  :fun list_if_set!: @_p.assert_union!(0x0, 14), CapnProto.Meta.Type.AS_list.read_from_pointer(@_p)
 
   :fun is_enum: @_p.check_union(0x0, 15)
   :fun enum!: @_p.assert_union!(0x0, 15), CapnProto.Meta.Type.AS_enum.read_from_pointer(@_p)
+  :fun enum_if_set!: @_p.assert_union!(0x0, 15), CapnProto.Meta.Type.AS_enum.read_from_pointer(@_p)
 
   :fun is_struct: @_p.check_union(0x0, 16)
   :fun struct!: @_p.assert_union!(0x0, 16), CapnProto.Meta.Type.AS_struct.read_from_pointer(@_p)
+  :fun struct_if_set!: @_p.assert_union!(0x0, 16), CapnProto.Meta.Type.AS_struct.read_from_pointer(@_p)
 
   :fun is_interface: @_p.check_union(0x0, 17)
   :fun interface!: @_p.assert_union!(0x0, 17), CapnProto.Meta.Type.AS_interface.read_from_pointer(@_p)
+  :fun interface_if_set!: @_p.assert_union!(0x0, 17), CapnProto.Meta.Type.AS_interface.read_from_pointer(@_p)
 
   :fun is_any_pointer: @_p.check_union(0x0, 18)
   :fun any_pointer!: @_p.assert_union!(0x0, 18), CapnProto.Meta.Type.AS_anyPointer.read_from_pointer(@_p)
+  :fun any_pointer_if_set!: @_p.assert_union!(0x0, 18), CapnProto.Meta.Type.AS_anyPointer.read_from_pointer(@_p)
 
 :struct box CapnProto.Meta.Type.AS_list
   :let _p CapnProto.Pointer.Struct
@@ -329,6 +417,7 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun element_type: CapnProto.Meta.Type.read_from_pointer(@_p.struct(0))
+  :fun element_type_if_set!: CapnProto.Meta.Type.read_from_pointer(@_p.struct_if_set!(0))
 
 :struct box CapnProto.Meta.Type.AS_enum
   :let _p CapnProto.Pointer.Struct
@@ -338,8 +427,10 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun type_id: @_p.u64(0x8)
+  :fun type_id_if_set!: @_p.u64_if_set!(0x8)
 
   :fun brand: CapnProto.Meta.Brand.read_from_pointer(@_p.struct(0))
+  :fun brand_if_set!: CapnProto.Meta.Brand.read_from_pointer(@_p.struct_if_set!(0))
 
 :struct box CapnProto.Meta.Type.AS_struct
   :let _p CapnProto.Pointer.Struct
@@ -349,8 +440,10 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun type_id: @_p.u64(0x8)
+  :fun type_id_if_set!: @_p.u64_if_set!(0x8)
 
   :fun brand: CapnProto.Meta.Brand.read_from_pointer(@_p.struct(0))
+  :fun brand_if_set!: CapnProto.Meta.Brand.read_from_pointer(@_p.struct_if_set!(0))
 
 :struct box CapnProto.Meta.Type.AS_interface
   :let _p CapnProto.Pointer.Struct
@@ -360,8 +453,10 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun type_id: @_p.u64(0x8)
+  :fun type_id_if_set!: @_p.u64_if_set!(0x8)
 
   :fun brand: CapnProto.Meta.Brand.read_from_pointer(@_p.struct(0))
+  :fun brand_if_set!: CapnProto.Meta.Brand.read_from_pointer(@_p.struct_if_set!(0))
 
 :struct box CapnProto.Meta.Type.AS_anyPointer
   :let _p CapnProto.Pointer.Struct
@@ -372,12 +467,15 @@
 
   :fun is_unconstrained: @_p.check_union(0x8, 0)
   :fun unconstrained!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained.read_from_pointer(@_p)
+  :fun unconstrained_if_set!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained.read_from_pointer(@_p)
 
   :fun is_parameter: @_p.check_union(0x8, 1)
   :fun parameter!: @_p.assert_union!(0x8, 1), CapnProto.Meta.Type.AS_anyPointer.AS_parameter.read_from_pointer(@_p)
+  :fun parameter_if_set!: @_p.assert_union!(0x8, 1), CapnProto.Meta.Type.AS_anyPointer.AS_parameter.read_from_pointer(@_p)
 
   :fun is_implicit_method_parameter: @_p.check_union(0x8, 2)
   :fun implicit_method_parameter!: @_p.assert_union!(0x8, 2), CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter.read_from_pointer(@_p)
+  :fun implicit_method_parameter_if_set!: @_p.assert_union!(0x8, 2), CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter.read_from_pointer(@_p)
 
 :struct box CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained
   :let _p CapnProto.Pointer.Struct
@@ -388,15 +486,19 @@
 
   :fun is_any_kind: @_p.check_union(0xa, 0)
   :fun any_kind!: @_p.assert_union!(0xa, 0), None
+  :fun any_kind_if_set!: @_p.assert_union!(0xa, 0), None
 
   :fun is_struct: @_p.check_union(0xa, 1)
   :fun struct!: @_p.assert_union!(0xa, 1), None
+  :fun struct_if_set!: @_p.assert_union!(0xa, 1), None
 
   :fun is_list: @_p.check_union(0xa, 2)
   :fun list!: @_p.assert_union!(0xa, 2), None
+  :fun list_if_set!: @_p.assert_union!(0xa, 2), None
 
   :fun is_capability: @_p.check_union(0xa, 3)
   :fun capability!: @_p.assert_union!(0xa, 3), None
+  :fun capability_if_set!: @_p.assert_union!(0xa, 3), None
 
 :struct box CapnProto.Meta.Type.AS_anyPointer.AS_parameter
   :let _p CapnProto.Pointer.Struct
@@ -406,8 +508,10 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun scope_id: @_p.u64(0x10)
+  :fun scope_id_if_set!: @_p.u64_if_set!(0x10)
 
   :fun parameter_index: @_p.u16(0xa)
+  :fun parameter_index_if_set!: @_p.u16_if_set!(0xa)
 
 :struct box CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter
   :let _p CapnProto.Pointer.Struct
@@ -417,6 +521,7 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun parameter_index: @_p.u16(0xa)
+  :fun parameter_index_if_set!: @_p.u16_if_set!(0xa)
 
 :struct box CapnProto.Meta.Brand
   :let _p CapnProto.Pointer.Struct
@@ -426,6 +531,7 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun scopes: CapnProto.List(CapnProto.Meta.Brand.Scope).read_from_pointer(@_p.list(0))
+  :fun scopes_if_set!: CapnProto.List(CapnProto.Meta.Brand.Scope).read_from_pointer(@_p.list_if_set!(0))
 
 :struct box CapnProto.Meta.Brand.Scope
   :let _p CapnProto.Pointer.Struct
@@ -435,12 +541,15 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun scope_id: @_p.u64(0x0)
+  :fun scope_id_if_set!: @_p.u64_if_set!(0x0)
 
   :fun is_bind: @_p.check_union(0x8, 0)
   :fun bind!: @_p.assert_union!(0x8, 0), CapnProto.List(CapnProto.Meta.Brand.Binding).read_from_pointer(@_p.list(0))
+  :fun bind_if_set!: @_p.assert_union!(0x8, 0), CapnProto.List(CapnProto.Meta.Brand.Binding).read_from_pointer(@_p.list_if_set!(0))
 
   :fun is_inherit: @_p.check_union(0x8, 1)
   :fun inherit!: @_p.assert_union!(0x8, 1), None
+  :fun inherit_if_set!: @_p.assert_union!(0x8, 1), None
 
 :struct box CapnProto.Meta.Brand.Binding
   :let _p CapnProto.Pointer.Struct
@@ -451,9 +560,11 @@
 
   :fun is_unbound: @_p.check_union(0x0, 0)
   :fun unbound!: @_p.assert_union!(0x0, 0), None
+  :fun unbound_if_set!: @_p.assert_union!(0x0, 0), None
 
   :fun is_type: @_p.check_union(0x0, 1)
   :fun type!: @_p.assert_union!(0x0, 1), CapnProto.Meta.Type.read_from_pointer(@_p.struct(0))
+  :fun type_if_set!: @_p.assert_union!(0x0, 1), CapnProto.Meta.Type.read_from_pointer(@_p.struct_if_set!(0))
 
 :struct box CapnProto.Meta.Value
   :let _p CapnProto.Pointer.Struct
@@ -464,60 +575,79 @@
 
   :fun is_void: @_p.check_union(0x0, 0)
   :fun void!: @_p.assert_union!(0x0, 0), None
+  :fun void_if_set!: @_p.assert_union!(0x0, 0), None
 
   :fun is_bool: @_p.check_union(0x0, 1)
   :fun bool!: @_p.assert_union!(0x0, 1), @_p.bool(0x2, 0b00000001)
+  :fun bool_if_set!: @_p.assert_union!(0x0, 1), @_p.bool_if_set!(0x2, 0b00000001)
 
   :fun is_int8: @_p.check_union(0x0, 2)
   :fun int8!: @_p.assert_union!(0x0, 2), @_p.i8(0x2)
+  :fun int8_if_set!: @_p.assert_union!(0x0, 2), @_p.i8_if_set!(0x2)
 
   :fun is_int16: @_p.check_union(0x0, 3)
   :fun int16!: @_p.assert_union!(0x0, 3), @_p.i16(0x2)
+  :fun int16_if_set!: @_p.assert_union!(0x0, 3), @_p.i16_if_set!(0x2)
 
   :fun is_int32: @_p.check_union(0x0, 4)
   :fun int32!: @_p.assert_union!(0x0, 4), @_p.i32(0x4)
+  :fun int32_if_set!: @_p.assert_union!(0x0, 4), @_p.i32_if_set!(0x4)
 
   :fun is_int64: @_p.check_union(0x0, 5)
   :fun int64!: @_p.assert_union!(0x0, 5), @_p.i64(0x8)
+  :fun int64_if_set!: @_p.assert_union!(0x0, 5), @_p.i64_if_set!(0x8)
 
   :fun is_uint8: @_p.check_union(0x0, 6)
   :fun uint8!: @_p.assert_union!(0x0, 6), @_p.u8(0x2)
+  :fun uint8_if_set!: @_p.assert_union!(0x0, 6), @_p.u8_if_set!(0x2)
 
   :fun is_uint16: @_p.check_union(0x0, 7)
   :fun uint16!: @_p.assert_union!(0x0, 7), @_p.u16(0x2)
+  :fun uint16_if_set!: @_p.assert_union!(0x0, 7), @_p.u16_if_set!(0x2)
 
   :fun is_uint32: @_p.check_union(0x0, 8)
   :fun uint32!: @_p.assert_union!(0x0, 8), @_p.u32(0x4)
+  :fun uint32_if_set!: @_p.assert_union!(0x0, 8), @_p.u32_if_set!(0x4)
 
   :fun is_uint64: @_p.check_union(0x0, 9)
   :fun uint64!: @_p.assert_union!(0x0, 9), @_p.u64(0x8)
+  :fun uint64_if_set!: @_p.assert_union!(0x0, 9), @_p.u64_if_set!(0x8)
 
   :fun is_float32: @_p.check_union(0x0, 10)
   :fun float32!: @_p.assert_union!(0x0, 10), @_p.f32(0x4)
+  :fun float32_if_set!: @_p.assert_union!(0x0, 10), @_p.f32_if_set!(0x4)
 
   :fun is_float64: @_p.check_union(0x0, 11)
   :fun float64!: @_p.assert_union!(0x0, 11), @_p.f64(0x8)
+  :fun float64_if_set!: @_p.assert_union!(0x0, 11), @_p.f64_if_set!(0x8)
 
   :fun is_text: @_p.check_union(0x0, 12)
   :fun text!: @_p.assert_union!(0x0, 12), @_p.text(0)
+  :fun text_if_set!: @_p.assert_union!(0x0, 12), @_p.text_if_set!(0)
 
   :fun is_data: @_p.check_union(0x0, 13)
   :fun data!: @_p.assert_union!(0x0, 13), @_p.data(0)
+  :fun data_if_set!: @_p.assert_union!(0x0, 13), @_p.data_if_set!(0)
 
   :fun is_list: @_p.check_union(0x0, 14)
   :fun list!: @_p.assert_union!(0x0, 14), None // UNHANDLED: anyPointer
+  :fun list_if_set!: @_p.assert_union!(0x0, 14), None // UNHANDLED: anyPointer
 
   :fun is_enum: @_p.check_union(0x0, 15)
   :fun enum!: @_p.assert_union!(0x0, 15), @_p.u16(0x2)
+  :fun enum_if_set!: @_p.assert_union!(0x0, 15), @_p.u16_if_set!(0x2)
 
   :fun is_struct: @_p.check_union(0x0, 16)
   :fun struct!: @_p.assert_union!(0x0, 16), None // UNHANDLED: anyPointer
+  :fun struct_if_set!: @_p.assert_union!(0x0, 16), None // UNHANDLED: anyPointer
 
   :fun is_interface: @_p.check_union(0x0, 17)
   :fun interface!: @_p.assert_union!(0x0, 17), None
+  :fun interface_if_set!: @_p.assert_union!(0x0, 17), None
 
   :fun is_any_pointer: @_p.check_union(0x0, 18)
   :fun any_pointer!: @_p.assert_union!(0x0, 18), None // UNHANDLED: anyPointer
+  :fun any_pointer_if_set!: @_p.assert_union!(0x0, 18), None // UNHANDLED: anyPointer
 
 :struct box CapnProto.Meta.Annotation
   :let _p CapnProto.Pointer.Struct
@@ -527,10 +657,13 @@
   :const capn_proto_pointer_count U16: 2
 
   :fun id: @_p.u64(0x0)
+  :fun id_if_set!: @_p.u64_if_set!(0x0)
 
   :fun value: CapnProto.Meta.Value.read_from_pointer(@_p.struct(0))
+  :fun value_if_set!: CapnProto.Meta.Value.read_from_pointer(@_p.struct_if_set!(0))
 
   :fun brand: CapnProto.Meta.Brand.read_from_pointer(@_p.struct(1))
+  :fun brand_if_set!: CapnProto.Meta.Brand.read_from_pointer(@_p.struct_if_set!(1))
 
 :enum CapnProto.Meta.ElementSize
   :bit_width 16
@@ -559,8 +692,10 @@
   :const capn_proto_pointer_count U16: 2
 
   :fun nodes: CapnProto.List(CapnProto.Meta.Node).read_from_pointer(@_p.list(0))
+  :fun nodes_if_set!: CapnProto.List(CapnProto.Meta.Node).read_from_pointer(@_p.list_if_set!(0))
 
   :fun requested_files: CapnProto.List(CapnProto.Meta.CodeGeneratorRequest.RequestedFile).read_from_pointer(@_p.list(1))
+  :fun requested_files_if_set!: CapnProto.List(CapnProto.Meta.CodeGeneratorRequest.RequestedFile).read_from_pointer(@_p.list_if_set!(1))
 
 :struct box CapnProto.Meta.CodeGeneratorRequest.RequestedFile
   :let _p CapnProto.Pointer.Struct
@@ -570,10 +705,13 @@
   :const capn_proto_pointer_count U16: 2
 
   :fun id: @_p.u64(0x0)
+  :fun id_if_set!: @_p.u64_if_set!(0x0)
 
   :fun filename: @_p.text(0)
+  :fun filename_if_set!: @_p.text_if_set!(0)
 
   :fun imports: CapnProto.List(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import).read_from_pointer(@_p.list(1))
+  :fun imports_if_set!: CapnProto.List(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import).read_from_pointer(@_p.list_if_set!(1))
 
 :struct box CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import
   :let _p CapnProto.Pointer.Struct
@@ -583,8 +721,10 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun id: @_p.u64(0x0)
+  :fun id_if_set!: @_p.u64_if_set!(0x0)
 
   :fun name: @_p.text(0)
+  :fun name_if_set!: @_p.text_if_set!(0)
 
 :struct CapnProto.Meta.Node.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -594,33 +734,41 @@
   :const capn_proto_pointer_count U16: 6
 
   :fun id: @_p.u64(0x0)
+  :fun id_if_set!: @_p.u64_if_set!(0x0)
   :fun ref "id="(new_value): @_p.set_u64(0x0, new_value, 0)
 
   :fun ref display_name: @_p.text(0)
+  :fun ref display_name_if_set!: @_p.text_if_set!(0)
   :fun ref "display_name="(new_value): @_p.set_text(0, new_value, "")
 
   :fun display_name_prefix_length: @_p.u32(0x8)
+  :fun display_name_prefix_length_if_set!: @_p.u32_if_set!(0x8)
   :fun ref "display_name_prefix_length="(new_value): @_p.set_u32(0x8, new_value, 0)
 
   :fun scope_id: @_p.u64(0x10)
+  :fun scope_id_if_set!: @_p.u64_if_set!(0x10)
   :fun ref "scope_id="(new_value): @_p.set_u64(0x10, new_value, 0)
 
   :fun ref nested_nodes: CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).from_pointer(@_p.list(1))
+  :fun ref nested_nodes_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_nested_nodes(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).from_pointer(@_p.init_list(1, 1, 1, new_count))
 
   :fun ref annotations: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list(2))
+  :fun ref annotations_if_set!: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list_if_set!(2))
   :fun ref init_annotations(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(2, 1, 2, new_count))
 
   :fun is_file: @_p.check_union(0xc, 0)
   :fun file!: @_p.assert_union!(0xc, 0), None
+  :fun file_if_set!: @_p.assert_union!(0xc, 0), None
   :fun ref init_file
     @_p.mark_union(0xc, 0)
     None
 
   :fun is_struct: @_p.check_union(0xc, 1)
   :fun ref struct!: @_p.assert_union!(0xc, 1), CapnProto.Meta.Node.AS_struct.Builder.from_pointer(@_p)
+  :fun ref struct_if_set!: @_p.assert_union!(0xc, 1), CapnProto.Meta.Node.AS_struct.Builder.from_pointer(@_p)
   :fun ref init_struct
     @_p.clear_16(0xe) // data_word_count
     @_p.clear_16(0x18) // pointer_count
@@ -634,6 +782,7 @@
 
   :fun is_enum: @_p.check_union(0xc, 2)
   :fun ref enum!: @_p.assert_union!(0xc, 2), CapnProto.Meta.Node.AS_enum.Builder.from_pointer(@_p)
+  :fun ref enum_if_set!: @_p.assert_union!(0xc, 2), CapnProto.Meta.Node.AS_enum.Builder.from_pointer(@_p)
   :fun ref init_enum
     @_p.clear_pointer(3) // enumerants
     @_p.mark_union(0xc, 2)
@@ -641,6 +790,7 @@
 
   :fun is_interface: @_p.check_union(0xc, 3)
   :fun ref interface!: @_p.assert_union!(0xc, 3), CapnProto.Meta.Node.AS_interface.Builder.from_pointer(@_p)
+  :fun ref interface_if_set!: @_p.assert_union!(0xc, 3), CapnProto.Meta.Node.AS_interface.Builder.from_pointer(@_p)
   :fun ref init_interface
     @_p.clear_pointer(3) // methods
     @_p.clear_pointer(4) // superclasses
@@ -649,6 +799,7 @@
 
   :fun is_const: @_p.check_union(0xc, 4)
   :fun ref const!: @_p.assert_union!(0xc, 4), CapnProto.Meta.Node.AS_const.Builder.from_pointer(@_p)
+  :fun ref const_if_set!: @_p.assert_union!(0xc, 4), CapnProto.Meta.Node.AS_const.Builder.from_pointer(@_p)
   :fun ref init_const
     @_p.clear_pointer(3) // type
     @_p.clear_pointer(4) // value
@@ -657,6 +808,7 @@
 
   :fun is_annotation: @_p.check_union(0xc, 5)
   :fun ref annotation!: @_p.assert_union!(0xc, 5), CapnProto.Meta.Node.AS_annotation.Builder.from_pointer(@_p)
+  :fun ref annotation_if_set!: @_p.assert_union!(0xc, 5), CapnProto.Meta.Node.AS_annotation.Builder.from_pointer(@_p)
   :fun ref init_annotation
     @_p.clear_pointer(3) // type
     @_p.set_bool(0xe, 0b00000001, False) // targets_file
@@ -675,10 +827,12 @@
     CapnProto.Meta.Node.AS_annotation.Builder.from_pointer(@_p)
 
   :fun ref parameters: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list(5))
+  :fun ref parameters_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list_if_set!(5))
   :fun ref init_parameters(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.init_list(5, 0, 1, new_count))
 
   :fun is_generic: @_p.bool(0x24, 0b00000001)
+  :fun is_generic_if_set!: @_p.bool_if_set!(0x24, 0b00000001)
   :fun ref "is_generic="(new_value): @_p.set_bool(0x24, 0b00000001, Bool[new_value])
 
 :struct CapnProto.Meta.Node.AS_struct.Builder
@@ -689,24 +843,31 @@
   :const capn_proto_pointer_count U16: 6
 
   :fun data_word_count: @_p.u16(0xe)
+  :fun data_word_count_if_set!: @_p.u16_if_set!(0xe)
   :fun ref "data_word_count="(new_value): @_p.set_u16(0xe, new_value, 0)
 
   :fun pointer_count: @_p.u16(0x18)
+  :fun pointer_count_if_set!: @_p.u16_if_set!(0x18)
   :fun ref "pointer_count="(new_value): @_p.set_u16(0x18, new_value, 0)
 
   :fun preferred_list_encoding: CapnProto.Meta.ElementSize._new(@_p.u16(0x1a))
+  :fun preferred_list_encoding_if_set!: CapnProto.Meta.ElementSize._new(@_p.u16_if_set!(0x1a))
   :fun ref "preferred_list_encoding="(new_value): @_p.set_u16(0x1a, CapnProto.Meta.ElementSize[new_value].u16, 0)
 
   :fun is_group: @_p.bool(0x1c, 0b00000001)
+  :fun is_group_if_set!: @_p.bool_if_set!(0x1c, 0b00000001)
   :fun ref "is_group="(new_value): @_p.set_bool(0x1c, 0b00000001, Bool[new_value])
 
   :fun discriminant_count: @_p.u16(0x1e)
+  :fun discriminant_count_if_set!: @_p.u16_if_set!(0x1e)
   :fun ref "discriminant_count="(new_value): @_p.set_u16(0x1e, new_value, 0)
 
   :fun discriminant_offset: @_p.u32(0x20)
+  :fun discriminant_offset_if_set!: @_p.u32_if_set!(0x20)
   :fun ref "discriminant_offset="(new_value): @_p.set_u32(0x20, new_value, 0)
 
   :fun ref fields: CapnProto.List.Builder(CapnProto.Meta.Field.Builder).from_pointer(@_p.list(3))
+  :fun ref fields_if_set!: CapnProto.List.Builder(CapnProto.Meta.Field.Builder).from_pointer(@_p.list_if_set!(3))
   :fun ref init_fields(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Field.Builder).from_pointer(@_p.init_list(3, 3, 4, new_count))
 
@@ -718,6 +879,7 @@
   :const capn_proto_pointer_count U16: 6
 
   :fun ref enumerants: CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.list(3))
+  :fun ref enumerants_if_set!: CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.list_if_set!(3))
   :fun ref init_enumerants(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.init_list(3, 1, 2, new_count))
 
@@ -729,10 +891,12 @@
   :const capn_proto_pointer_count U16: 6
 
   :fun ref methods: CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.list(3))
+  :fun ref methods_if_set!: CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.list_if_set!(3))
   :fun ref init_methods(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.init_list(3, 3, 5, new_count))
 
   :fun ref superclasses: CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.list(4))
+  :fun ref superclasses_if_set!: CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.list_if_set!(4))
   :fun ref init_superclasses(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.init_list(4, 1, 1, new_count))
 
@@ -744,8 +908,10 @@
   :const capn_proto_pointer_count U16: 6
 
   :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(3, 3, 1))
+  :fun ref type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(3, 3, 1))
 
   :fun ref value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(4, 2, 1))
+  :fun ref value_if_set!: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct_if_set!(4, 2, 1))
 
 :struct CapnProto.Meta.Node.AS_annotation.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -755,41 +921,54 @@
   :const capn_proto_pointer_count U16: 6
 
   :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(3, 3, 1))
+  :fun ref type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(3, 3, 1))
 
   :fun targets_file: @_p.bool(0xe, 0b00000001)
+  :fun targets_file_if_set!: @_p.bool_if_set!(0xe, 0b00000001)
   :fun ref "targets_file="(new_value): @_p.set_bool(0xe, 0b00000001, Bool[new_value])
 
   :fun targets_const: @_p.bool(0xe, 0b00000010)
+  :fun targets_const_if_set!: @_p.bool_if_set!(0xe, 0b00000010)
   :fun ref "targets_const="(new_value): @_p.set_bool(0xe, 0b00000010, Bool[new_value])
 
   :fun targets_enum: @_p.bool(0xe, 0b00000100)
+  :fun targets_enum_if_set!: @_p.bool_if_set!(0xe, 0b00000100)
   :fun ref "targets_enum="(new_value): @_p.set_bool(0xe, 0b00000100, Bool[new_value])
 
   :fun targets_enumerant: @_p.bool(0xe, 0b00001000)
+  :fun targets_enumerant_if_set!: @_p.bool_if_set!(0xe, 0b00001000)
   :fun ref "targets_enumerant="(new_value): @_p.set_bool(0xe, 0b00001000, Bool[new_value])
 
   :fun targets_struct: @_p.bool(0xe, 0b00010000)
+  :fun targets_struct_if_set!: @_p.bool_if_set!(0xe, 0b00010000)
   :fun ref "targets_struct="(new_value): @_p.set_bool(0xe, 0b00010000, Bool[new_value])
 
   :fun targets_field: @_p.bool(0xe, 0b00100000)
+  :fun targets_field_if_set!: @_p.bool_if_set!(0xe, 0b00100000)
   :fun ref "targets_field="(new_value): @_p.set_bool(0xe, 0b00100000, Bool[new_value])
 
   :fun targets_union: @_p.bool(0xe, 0b01000000)
+  :fun targets_union_if_set!: @_p.bool_if_set!(0xe, 0b01000000)
   :fun ref "targets_union="(new_value): @_p.set_bool(0xe, 0b01000000, Bool[new_value])
 
   :fun targets_group: @_p.bool(0xe, 0b10000000)
+  :fun targets_group_if_set!: @_p.bool_if_set!(0xe, 0b10000000)
   :fun ref "targets_group="(new_value): @_p.set_bool(0xe, 0b10000000, Bool[new_value])
 
   :fun targets_interface: @_p.bool(0xf, 0b00000001)
+  :fun targets_interface_if_set!: @_p.bool_if_set!(0xf, 0b00000001)
   :fun ref "targets_interface="(new_value): @_p.set_bool(0xf, 0b00000001, Bool[new_value])
 
   :fun targets_method: @_p.bool(0xf, 0b00000010)
+  :fun targets_method_if_set!: @_p.bool_if_set!(0xf, 0b00000010)
   :fun ref "targets_method="(new_value): @_p.set_bool(0xf, 0b00000010, Bool[new_value])
 
   :fun targets_param: @_p.bool(0xf, 0b00000100)
+  :fun targets_param_if_set!: @_p.bool_if_set!(0xf, 0b00000100)
   :fun ref "targets_param="(new_value): @_p.set_bool(0xf, 0b00000100, Bool[new_value])
 
   :fun targets_annotation: @_p.bool(0xf, 0b00001000)
+  :fun targets_annotation_if_set!: @_p.bool_if_set!(0xf, 0b00001000)
   :fun ref "targets_annotation="(new_value): @_p.set_bool(0xf, 0b00001000, Bool[new_value])
 
 :struct CapnProto.Meta.Node.Parameter.Builder
@@ -800,6 +979,7 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun ref name: @_p.text(0)
+  :fun ref name_if_set!: @_p.text_if_set!(0)
   :fun ref "name="(new_value): @_p.set_text(0, new_value, "")
 
 :struct CapnProto.Meta.Node.NestedNode.Builder
@@ -810,9 +990,11 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun ref name: @_p.text(0)
+  :fun ref name_if_set!: @_p.text_if_set!(0)
   :fun ref "name="(new_value): @_p.set_text(0, new_value, "")
 
   :fun id: @_p.u64(0x0)
+  :fun id_if_set!: @_p.u64_if_set!(0x0)
   :fun ref "id="(new_value): @_p.set_u64(0x0, new_value, 0)
 
 :struct CapnProto.Meta.Field.Builder
@@ -825,20 +1007,25 @@
   :const no_discriminant U16: 65535
 
   :fun ref name: @_p.text(0)
+  :fun ref name_if_set!: @_p.text_if_set!(0)
   :fun ref "name="(new_value): @_p.set_text(0, new_value, "")
 
   :fun code_order: @_p.u16(0x0)
+  :fun code_order_if_set!: @_p.u16_if_set!(0x0)
   :fun ref "code_order="(new_value): @_p.set_u16(0x0, new_value, 0)
 
   :fun ref annotations: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list(1))
+  :fun ref annotations_if_set!: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_annotations(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
 
   :fun discriminant_value: @_p.u16(0x2).bit_xor(65535)
+  :fun discriminant_value_if_set!: @_p.u16_if_set!(0x2).bit_xor(65535)
   :fun ref "discriminant_value="(new_value): @_p.set_u16(0x2, new_value, 65535)
 
   :fun is_slot: @_p.check_union(0x8, 0)
   :fun ref slot!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Field.AS_slot.Builder.from_pointer(@_p)
+  :fun ref slot_if_set!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Field.AS_slot.Builder.from_pointer(@_p)
   :fun ref init_slot
     @_p.clear_32(0x4) // offset
     @_p.clear_pointer(2) // type
@@ -849,12 +1036,14 @@
 
   :fun is_group: @_p.check_union(0x8, 1)
   :fun ref group!: @_p.assert_union!(0x8, 1), CapnProto.Meta.Field.AS_group.Builder.from_pointer(@_p)
+  :fun ref group_if_set!: @_p.assert_union!(0x8, 1), CapnProto.Meta.Field.AS_group.Builder.from_pointer(@_p)
   :fun ref init_group
     @_p.clear_64(0x10) // type_id
     @_p.mark_union(0x8, 1)
     CapnProto.Meta.Field.AS_group.Builder.from_pointer(@_p)
 
   :fun ref ordinal: CapnProto.Meta.Field.AS_ordinal.Builder.from_pointer(@_p)
+  :fun ref ordinal_if_set!: CapnProto.Meta.Field.AS_ordinal.Builder.from_pointer(@_p)
 
 :struct CapnProto.Meta.Field.AS_slot.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -864,13 +1053,17 @@
   :const capn_proto_pointer_count U16: 4
 
   :fun offset: @_p.u32(0x4)
+  :fun offset_if_set!: @_p.u32_if_set!(0x4)
   :fun ref "offset="(new_value): @_p.set_u32(0x4, new_value, 0)
 
   :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(2, 3, 1))
+  :fun ref type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(2, 3, 1))
 
   :fun ref default_value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(3, 2, 1))
+  :fun ref default_value_if_set!: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct_if_set!(3, 2, 1))
 
   :fun had_explicit_default: @_p.bool(0x10, 0b00000001)
+  :fun had_explicit_default_if_set!: @_p.bool_if_set!(0x10, 0b00000001)
   :fun ref "had_explicit_default="(new_value): @_p.set_bool(0x10, 0b00000001, Bool[new_value])
 
 :struct CapnProto.Meta.Field.AS_group.Builder
@@ -881,6 +1074,7 @@
   :const capn_proto_pointer_count U16: 4
 
   :fun type_id: @_p.u64(0x10)
+  :fun type_id_if_set!: @_p.u64_if_set!(0x10)
   :fun ref "type_id="(new_value): @_p.set_u64(0x10, new_value, 0)
 
 :struct CapnProto.Meta.Field.AS_ordinal.Builder
@@ -892,12 +1086,14 @@
 
   :fun is_implicit: @_p.check_union(0xa, 0)
   :fun implicit!: @_p.assert_union!(0xa, 0), None
+  :fun implicit_if_set!: @_p.assert_union!(0xa, 0), None
   :fun ref init_implicit
     @_p.mark_union(0xa, 0)
     None
 
   :fun is_explicit: @_p.check_union(0xa, 1)
   :fun explicit!: @_p.assert_union!(0xa, 1), @_p.u16(0xc)
+  :fun explicit_if_set!: @_p.assert_union!(0xa, 1), @_p.u16_if_set!(0xc)
   :fun ref init_explicit(new_value)
     @_p.set_u16(0xc, new_value, 0)
     @_p.mark_union(0xa, 1)
@@ -911,12 +1107,15 @@
   :const capn_proto_pointer_count U16: 2
 
   :fun ref name: @_p.text(0)
+  :fun ref name_if_set!: @_p.text_if_set!(0)
   :fun ref "name="(new_value): @_p.set_text(0, new_value, "")
 
   :fun code_order: @_p.u16(0x0)
+  :fun code_order_if_set!: @_p.u16_if_set!(0x0)
   :fun ref "code_order="(new_value): @_p.set_u16(0x0, new_value, 0)
 
   :fun ref annotations: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list(1))
+  :fun ref annotations_if_set!: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_annotations(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
 
@@ -928,9 +1127,11 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun id: @_p.u64(0x0)
+  :fun id_if_set!: @_p.u64_if_set!(0x0)
   :fun ref "id="(new_value): @_p.set_u64(0x0, new_value, 0)
 
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
+  :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(0, 0, 1))
 
 :struct CapnProto.Meta.Method.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -940,26 +1141,34 @@
   :const capn_proto_pointer_count U16: 5
 
   :fun ref name: @_p.text(0)
+  :fun ref name_if_set!: @_p.text_if_set!(0)
   :fun ref "name="(new_value): @_p.set_text(0, new_value, "")
 
   :fun code_order: @_p.u16(0x0)
+  :fun code_order_if_set!: @_p.u16_if_set!(0x0)
   :fun ref "code_order="(new_value): @_p.set_u16(0x0, new_value, 0)
 
   :fun param_struct_type: @_p.u64(0x8)
+  :fun param_struct_type_if_set!: @_p.u64_if_set!(0x8)
   :fun ref "param_struct_type="(new_value): @_p.set_u64(0x8, new_value, 0)
 
   :fun result_struct_type: @_p.u64(0x10)
+  :fun result_struct_type_if_set!: @_p.u64_if_set!(0x10)
   :fun ref "result_struct_type="(new_value): @_p.set_u64(0x10, new_value, 0)
 
   :fun ref annotations: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list(1))
+  :fun ref annotations_if_set!: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_annotations(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
 
   :fun ref param_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(2, 0, 1))
+  :fun ref param_brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(2, 0, 1))
 
   :fun ref result_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(3, 0, 1))
+  :fun ref result_brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(3, 0, 1))
 
   :fun ref implicit_parameters: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list(4))
+  :fun ref implicit_parameters_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list_if_set!(4))
   :fun ref init_implicit_parameters(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.init_list(4, 0, 1, new_count))
 
@@ -972,90 +1181,105 @@
 
   :fun is_void: @_p.check_union(0x0, 0)
   :fun void!: @_p.assert_union!(0x0, 0), None
+  :fun void_if_set!: @_p.assert_union!(0x0, 0), None
   :fun ref init_void
     @_p.mark_union(0x0, 0)
     None
 
   :fun is_bool: @_p.check_union(0x0, 1)
   :fun bool!: @_p.assert_union!(0x0, 1), None
+  :fun bool_if_set!: @_p.assert_union!(0x0, 1), None
   :fun ref init_bool
     @_p.mark_union(0x0, 1)
     None
 
   :fun is_int8: @_p.check_union(0x0, 2)
   :fun int8!: @_p.assert_union!(0x0, 2), None
+  :fun int8_if_set!: @_p.assert_union!(0x0, 2), None
   :fun ref init_int8
     @_p.mark_union(0x0, 2)
     None
 
   :fun is_int16: @_p.check_union(0x0, 3)
   :fun int16!: @_p.assert_union!(0x0, 3), None
+  :fun int16_if_set!: @_p.assert_union!(0x0, 3), None
   :fun ref init_int16
     @_p.mark_union(0x0, 3)
     None
 
   :fun is_int32: @_p.check_union(0x0, 4)
   :fun int32!: @_p.assert_union!(0x0, 4), None
+  :fun int32_if_set!: @_p.assert_union!(0x0, 4), None
   :fun ref init_int32
     @_p.mark_union(0x0, 4)
     None
 
   :fun is_int64: @_p.check_union(0x0, 5)
   :fun int64!: @_p.assert_union!(0x0, 5), None
+  :fun int64_if_set!: @_p.assert_union!(0x0, 5), None
   :fun ref init_int64
     @_p.mark_union(0x0, 5)
     None
 
   :fun is_uint8: @_p.check_union(0x0, 6)
   :fun uint8!: @_p.assert_union!(0x0, 6), None
+  :fun uint8_if_set!: @_p.assert_union!(0x0, 6), None
   :fun ref init_uint8
     @_p.mark_union(0x0, 6)
     None
 
   :fun is_uint16: @_p.check_union(0x0, 7)
   :fun uint16!: @_p.assert_union!(0x0, 7), None
+  :fun uint16_if_set!: @_p.assert_union!(0x0, 7), None
   :fun ref init_uint16
     @_p.mark_union(0x0, 7)
     None
 
   :fun is_uint32: @_p.check_union(0x0, 8)
   :fun uint32!: @_p.assert_union!(0x0, 8), None
+  :fun uint32_if_set!: @_p.assert_union!(0x0, 8), None
   :fun ref init_uint32
     @_p.mark_union(0x0, 8)
     None
 
   :fun is_uint64: @_p.check_union(0x0, 9)
   :fun uint64!: @_p.assert_union!(0x0, 9), None
+  :fun uint64_if_set!: @_p.assert_union!(0x0, 9), None
   :fun ref init_uint64
     @_p.mark_union(0x0, 9)
     None
 
   :fun is_float32: @_p.check_union(0x0, 10)
   :fun float32!: @_p.assert_union!(0x0, 10), None
+  :fun float32_if_set!: @_p.assert_union!(0x0, 10), None
   :fun ref init_float32
     @_p.mark_union(0x0, 10)
     None
 
   :fun is_float64: @_p.check_union(0x0, 11)
   :fun float64!: @_p.assert_union!(0x0, 11), None
+  :fun float64_if_set!: @_p.assert_union!(0x0, 11), None
   :fun ref init_float64
     @_p.mark_union(0x0, 11)
     None
 
   :fun is_text: @_p.check_union(0x0, 12)
   :fun text!: @_p.assert_union!(0x0, 12), None
+  :fun text_if_set!: @_p.assert_union!(0x0, 12), None
   :fun ref init_text
     @_p.mark_union(0x0, 12)
     None
 
   :fun is_data: @_p.check_union(0x0, 13)
   :fun data!: @_p.assert_union!(0x0, 13), None
+  :fun data_if_set!: @_p.assert_union!(0x0, 13), None
   :fun ref init_data
     @_p.mark_union(0x0, 13)
     None
 
   :fun is_list: @_p.check_union(0x0, 14)
   :fun ref list!: @_p.assert_union!(0x0, 14), CapnProto.Meta.Type.AS_list.Builder.from_pointer(@_p)
+  :fun ref list_if_set!: @_p.assert_union!(0x0, 14), CapnProto.Meta.Type.AS_list.Builder.from_pointer(@_p)
   :fun ref init_list
     @_p.clear_pointer(0) // element_type
     @_p.mark_union(0x0, 14)
@@ -1063,6 +1287,7 @@
 
   :fun is_enum: @_p.check_union(0x0, 15)
   :fun ref enum!: @_p.assert_union!(0x0, 15), CapnProto.Meta.Type.AS_enum.Builder.from_pointer(@_p)
+  :fun ref enum_if_set!: @_p.assert_union!(0x0, 15), CapnProto.Meta.Type.AS_enum.Builder.from_pointer(@_p)
   :fun ref init_enum
     @_p.clear_64(0x8) // type_id
     @_p.clear_pointer(0) // brand
@@ -1071,6 +1296,7 @@
 
   :fun is_struct: @_p.check_union(0x0, 16)
   :fun ref struct!: @_p.assert_union!(0x0, 16), CapnProto.Meta.Type.AS_struct.Builder.from_pointer(@_p)
+  :fun ref struct_if_set!: @_p.assert_union!(0x0, 16), CapnProto.Meta.Type.AS_struct.Builder.from_pointer(@_p)
   :fun ref init_struct
     @_p.clear_64(0x8) // type_id
     @_p.clear_pointer(0) // brand
@@ -1079,6 +1305,7 @@
 
   :fun is_interface: @_p.check_union(0x0, 17)
   :fun ref interface!: @_p.assert_union!(0x0, 17), CapnProto.Meta.Type.AS_interface.Builder.from_pointer(@_p)
+  :fun ref interface_if_set!: @_p.assert_union!(0x0, 17), CapnProto.Meta.Type.AS_interface.Builder.from_pointer(@_p)
   :fun ref init_interface
     @_p.clear_64(0x8) // type_id
     @_p.clear_pointer(0) // brand
@@ -1087,6 +1314,7 @@
 
   :fun is_any_pointer: @_p.check_union(0x0, 18)
   :fun ref any_pointer!: @_p.assert_union!(0x0, 18), CapnProto.Meta.Type.AS_anyPointer.Builder.from_pointer(@_p)
+  :fun ref any_pointer_if_set!: @_p.assert_union!(0x0, 18), CapnProto.Meta.Type.AS_anyPointer.Builder.from_pointer(@_p)
   :fun ref init_any_pointer
     @_p.mark_union(0x0, 18)
     CapnProto.Meta.Type.AS_anyPointer.Builder.from_pointer(@_p)
@@ -1099,6 +1327,7 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun ref element_type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(0, 3, 1))
+  :fun ref element_type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(0, 3, 1))
 
 :struct CapnProto.Meta.Type.AS_enum.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1108,9 +1337,11 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun type_id: @_p.u64(0x8)
+  :fun type_id_if_set!: @_p.u64_if_set!(0x8)
   :fun ref "type_id="(new_value): @_p.set_u64(0x8, new_value, 0)
 
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
+  :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(0, 0, 1))
 
 :struct CapnProto.Meta.Type.AS_struct.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1120,9 +1351,11 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun type_id: @_p.u64(0x8)
+  :fun type_id_if_set!: @_p.u64_if_set!(0x8)
   :fun ref "type_id="(new_value): @_p.set_u64(0x8, new_value, 0)
 
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
+  :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(0, 0, 1))
 
 :struct CapnProto.Meta.Type.AS_interface.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1132,9 +1365,11 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun type_id: @_p.u64(0x8)
+  :fun type_id_if_set!: @_p.u64_if_set!(0x8)
   :fun ref "type_id="(new_value): @_p.set_u64(0x8, new_value, 0)
 
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
+  :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(0, 0, 1))
 
 :struct CapnProto.Meta.Type.AS_anyPointer.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1145,12 +1380,14 @@
 
   :fun is_unconstrained: @_p.check_union(0x8, 0)
   :fun ref unconstrained!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained.Builder.from_pointer(@_p)
+  :fun ref unconstrained_if_set!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained.Builder.from_pointer(@_p)
   :fun ref init_unconstrained
     @_p.mark_union(0x8, 0)
     CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained.Builder.from_pointer(@_p)
 
   :fun is_parameter: @_p.check_union(0x8, 1)
   :fun ref parameter!: @_p.assert_union!(0x8, 1), CapnProto.Meta.Type.AS_anyPointer.AS_parameter.Builder.from_pointer(@_p)
+  :fun ref parameter_if_set!: @_p.assert_union!(0x8, 1), CapnProto.Meta.Type.AS_anyPointer.AS_parameter.Builder.from_pointer(@_p)
   :fun ref init_parameter
     @_p.clear_64(0x10) // scope_id
     @_p.clear_16(0xa) // parameter_index
@@ -1159,6 +1396,7 @@
 
   :fun is_implicit_method_parameter: @_p.check_union(0x8, 2)
   :fun ref implicit_method_parameter!: @_p.assert_union!(0x8, 2), CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter.Builder.from_pointer(@_p)
+  :fun ref implicit_method_parameter_if_set!: @_p.assert_union!(0x8, 2), CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter.Builder.from_pointer(@_p)
   :fun ref init_implicit_method_parameter
     @_p.clear_16(0xa) // parameter_index
     @_p.mark_union(0x8, 2)
@@ -1173,24 +1411,28 @@
 
   :fun is_any_kind: @_p.check_union(0xa, 0)
   :fun any_kind!: @_p.assert_union!(0xa, 0), None
+  :fun any_kind_if_set!: @_p.assert_union!(0xa, 0), None
   :fun ref init_any_kind
     @_p.mark_union(0xa, 0)
     None
 
   :fun is_struct: @_p.check_union(0xa, 1)
   :fun struct!: @_p.assert_union!(0xa, 1), None
+  :fun struct_if_set!: @_p.assert_union!(0xa, 1), None
   :fun ref init_struct
     @_p.mark_union(0xa, 1)
     None
 
   :fun is_list: @_p.check_union(0xa, 2)
   :fun list!: @_p.assert_union!(0xa, 2), None
+  :fun list_if_set!: @_p.assert_union!(0xa, 2), None
   :fun ref init_list
     @_p.mark_union(0xa, 2)
     None
 
   :fun is_capability: @_p.check_union(0xa, 3)
   :fun capability!: @_p.assert_union!(0xa, 3), None
+  :fun capability_if_set!: @_p.assert_union!(0xa, 3), None
   :fun ref init_capability
     @_p.mark_union(0xa, 3)
     None
@@ -1203,9 +1445,11 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun scope_id: @_p.u64(0x10)
+  :fun scope_id_if_set!: @_p.u64_if_set!(0x10)
   :fun ref "scope_id="(new_value): @_p.set_u64(0x10, new_value, 0)
 
   :fun parameter_index: @_p.u16(0xa)
+  :fun parameter_index_if_set!: @_p.u16_if_set!(0xa)
   :fun ref "parameter_index="(new_value): @_p.set_u16(0xa, new_value, 0)
 
 :struct CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter.Builder
@@ -1216,6 +1460,7 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun parameter_index: @_p.u16(0xa)
+  :fun parameter_index_if_set!: @_p.u16_if_set!(0xa)
   :fun ref "parameter_index="(new_value): @_p.set_u16(0xa, new_value, 0)
 
 :struct CapnProto.Meta.Brand.Builder
@@ -1226,6 +1471,7 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun ref scopes: CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.list(0))
+  :fun ref scopes_if_set!: CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.list_if_set!(0))
   :fun ref init_scopes(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.init_list(0, 2, 1, new_count))
 
@@ -1237,16 +1483,19 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun scope_id: @_p.u64(0x0)
+  :fun scope_id_if_set!: @_p.u64_if_set!(0x0)
   :fun ref "scope_id="(new_value): @_p.set_u64(0x0, new_value, 0)
 
   :fun is_bind: @_p.check_union(0x8, 0)
   :fun ref bind!: @_p.assert_union!(0x8, 0), CapnProto.List.Builder(CapnProto.Meta.Brand.Binding.Builder).from_pointer(@_p.list(0))
+  :fun ref bind_if_set!: @_p.assert_union!(0x8, 0), CapnProto.List.Builder(CapnProto.Meta.Brand.Binding.Builder).from_pointer(@_p.list_if_set!(0))
   :fun ref init_bind(new_count)
     @_p.mark_union(0x8, 0)
     CapnProto.List.Builder(CapnProto.Meta.Brand.Binding.Builder).from_pointer(@_p.init_list(0, 1, 1, new_count))
 
   :fun is_inherit: @_p.check_union(0x8, 1)
   :fun inherit!: @_p.assert_union!(0x8, 1), None
+  :fun inherit_if_set!: @_p.assert_union!(0x8, 1), None
   :fun ref init_inherit
     @_p.mark_union(0x8, 1)
     None
@@ -1260,12 +1509,14 @@
 
   :fun is_unbound: @_p.check_union(0x0, 0)
   :fun unbound!: @_p.assert_union!(0x0, 0), None
+  :fun unbound_if_set!: @_p.assert_union!(0x0, 0), None
   :fun ref init_unbound
     @_p.mark_union(0x0, 0)
     None
 
   :fun is_type: @_p.check_union(0x0, 1)
   :fun ref type!: @_p.assert_union!(0x0, 1), CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(0, 3, 1))
+  :fun ref type_if_set!: @_p.assert_union!(0x0, 1), CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(0, 3, 1))
   :fun ref init_type
     @_p.clear_pointer(0) // type
     @_p.mark_union(0x0, 1)
@@ -1280,12 +1531,14 @@
 
   :fun is_void: @_p.check_union(0x0, 0)
   :fun void!: @_p.assert_union!(0x0, 0), None
+  :fun void_if_set!: @_p.assert_union!(0x0, 0), None
   :fun ref init_void
     @_p.mark_union(0x0, 0)
     None
 
   :fun is_bool: @_p.check_union(0x0, 1)
   :fun bool!: @_p.assert_union!(0x0, 1), @_p.bool(0x2, 0b00000001)
+  :fun bool_if_set!: @_p.assert_union!(0x0, 1), @_p.bool_if_set!(0x2, 0b00000001)
   :fun ref init_bool(new_value)
     @_p.set_bool(0x2, 0b00000001, Bool[new_value])
     @_p.mark_union(0x0, 1)
@@ -1293,6 +1546,7 @@
 
   :fun is_int8: @_p.check_union(0x0, 2)
   :fun int8!: @_p.assert_union!(0x0, 2), @_p.i8(0x2)
+  :fun int8_if_set!: @_p.assert_union!(0x0, 2), @_p.i8_if_set!(0x2)
   :fun ref init_int8(new_value)
     @_p.set_i8(0x2, new_value, 0)
     @_p.mark_union(0x0, 2)
@@ -1300,6 +1554,7 @@
 
   :fun is_int16: @_p.check_union(0x0, 3)
   :fun int16!: @_p.assert_union!(0x0, 3), @_p.i16(0x2)
+  :fun int16_if_set!: @_p.assert_union!(0x0, 3), @_p.i16_if_set!(0x2)
   :fun ref init_int16(new_value)
     @_p.set_i16(0x2, new_value, 0)
     @_p.mark_union(0x0, 3)
@@ -1307,6 +1562,7 @@
 
   :fun is_int32: @_p.check_union(0x0, 4)
   :fun int32!: @_p.assert_union!(0x0, 4), @_p.i32(0x4)
+  :fun int32_if_set!: @_p.assert_union!(0x0, 4), @_p.i32_if_set!(0x4)
   :fun ref init_int32(new_value)
     @_p.set_i32(0x4, new_value, 0)
     @_p.mark_union(0x0, 4)
@@ -1314,6 +1570,7 @@
 
   :fun is_int64: @_p.check_union(0x0, 5)
   :fun int64!: @_p.assert_union!(0x0, 5), @_p.i64(0x8)
+  :fun int64_if_set!: @_p.assert_union!(0x0, 5), @_p.i64_if_set!(0x8)
   :fun ref init_int64(new_value)
     @_p.set_i64(0x8, new_value, 0)
     @_p.mark_union(0x0, 5)
@@ -1321,6 +1578,7 @@
 
   :fun is_uint8: @_p.check_union(0x0, 6)
   :fun uint8!: @_p.assert_union!(0x0, 6), @_p.u8(0x2)
+  :fun uint8_if_set!: @_p.assert_union!(0x0, 6), @_p.u8_if_set!(0x2)
   :fun ref init_uint8(new_value)
     @_p.set_u8(0x2, new_value, 0)
     @_p.mark_union(0x0, 6)
@@ -1328,6 +1586,7 @@
 
   :fun is_uint16: @_p.check_union(0x0, 7)
   :fun uint16!: @_p.assert_union!(0x0, 7), @_p.u16(0x2)
+  :fun uint16_if_set!: @_p.assert_union!(0x0, 7), @_p.u16_if_set!(0x2)
   :fun ref init_uint16(new_value)
     @_p.set_u16(0x2, new_value, 0)
     @_p.mark_union(0x0, 7)
@@ -1335,6 +1594,7 @@
 
   :fun is_uint32: @_p.check_union(0x0, 8)
   :fun uint32!: @_p.assert_union!(0x0, 8), @_p.u32(0x4)
+  :fun uint32_if_set!: @_p.assert_union!(0x0, 8), @_p.u32_if_set!(0x4)
   :fun ref init_uint32(new_value)
     @_p.set_u32(0x4, new_value, 0)
     @_p.mark_union(0x0, 8)
@@ -1342,6 +1602,7 @@
 
   :fun is_uint64: @_p.check_union(0x0, 9)
   :fun uint64!: @_p.assert_union!(0x0, 9), @_p.u64(0x8)
+  :fun uint64_if_set!: @_p.assert_union!(0x0, 9), @_p.u64_if_set!(0x8)
   :fun ref init_uint64(new_value)
     @_p.set_u64(0x8, new_value, 0)
     @_p.mark_union(0x0, 9)
@@ -1349,6 +1610,7 @@
 
   :fun is_float32: @_p.check_union(0x0, 10)
   :fun float32!: @_p.assert_union!(0x0, 10), @_p.f32(0x4)
+  :fun float32_if_set!: @_p.assert_union!(0x0, 10), @_p.f32_if_set!(0x4)
   :fun ref init_float32(new_value)
     @_p.set_f32(0x4, new_value, 0.0)
     @_p.mark_union(0x0, 10)
@@ -1356,6 +1618,7 @@
 
   :fun is_float64: @_p.check_union(0x0, 11)
   :fun float64!: @_p.assert_union!(0x0, 11), @_p.f64(0x8)
+  :fun float64_if_set!: @_p.assert_union!(0x0, 11), @_p.f64_if_set!(0x8)
   :fun ref init_float64(new_value)
     @_p.set_f64(0x8, new_value, 0.0)
     @_p.mark_union(0x0, 11)
@@ -1363,6 +1626,7 @@
 
   :fun is_text: @_p.check_union(0x0, 12)
   :fun ref text!: @_p.assert_union!(0x0, 12), @_p.text(0)
+  :fun ref text_if_set!: @_p.assert_union!(0x0, 12), @_p.text_if_set!(0)
   :fun ref init_text(new_value)
     @_p.set_text(0, new_value, "")
     @_p.mark_union(0x0, 12)
@@ -1370,6 +1634,7 @@
 
   :fun is_data: @_p.check_union(0x0, 13)
   :fun ref data!: @_p.assert_union!(0x0, 13), @_p.data(0)
+  :fun ref data_if_set!: @_p.assert_union!(0x0, 13), @_p.data_if_set!(0)
   :fun ref init_data(new_value)
     @_p.set_data(0, new_value, b"")
     @_p.mark_union(0x0, 13)
@@ -1377,12 +1642,14 @@
 
   :fun is_list: @_p.check_union(0x0, 14)
   :fun ref list!: @_p.assert_union!(0x0, 14), None // UNHANDLED: anyPointer
+  :fun ref list_if_set!: @_p.assert_union!(0x0, 14), None // UNHANDLED: anyPointer
   :fun ref init_list(new_value None)
     @_p.mark_union(0x0, 14)
     None // UNHANDLED: anyPointer
 
   :fun is_enum: @_p.check_union(0x0, 15)
   :fun enum!: @_p.assert_union!(0x0, 15), @_p.u16(0x2)
+  :fun enum_if_set!: @_p.assert_union!(0x0, 15), @_p.u16_if_set!(0x2)
   :fun ref init_enum(new_value)
     @_p.set_u16(0x2, new_value, 0)
     @_p.mark_union(0x0, 15)
@@ -1390,18 +1657,21 @@
 
   :fun is_struct: @_p.check_union(0x0, 16)
   :fun ref struct!: @_p.assert_union!(0x0, 16), None // UNHANDLED: anyPointer
+  :fun ref struct_if_set!: @_p.assert_union!(0x0, 16), None // UNHANDLED: anyPointer
   :fun ref init_struct(new_value None)
     @_p.mark_union(0x0, 16)
     None // UNHANDLED: anyPointer
 
   :fun is_interface: @_p.check_union(0x0, 17)
   :fun interface!: @_p.assert_union!(0x0, 17), None
+  :fun interface_if_set!: @_p.assert_union!(0x0, 17), None
   :fun ref init_interface
     @_p.mark_union(0x0, 17)
     None
 
   :fun is_any_pointer: @_p.check_union(0x0, 18)
   :fun ref any_pointer!: @_p.assert_union!(0x0, 18), None // UNHANDLED: anyPointer
+  :fun ref any_pointer_if_set!: @_p.assert_union!(0x0, 18), None // UNHANDLED: anyPointer
   :fun ref init_any_pointer(new_value None)
     @_p.mark_union(0x0, 18)
     None // UNHANDLED: anyPointer
@@ -1414,11 +1684,14 @@
   :const capn_proto_pointer_count U16: 2
 
   :fun id: @_p.u64(0x0)
+  :fun id_if_set!: @_p.u64_if_set!(0x0)
   :fun ref "id="(new_value): @_p.set_u64(0x0, new_value, 0)
 
   :fun ref value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(0, 2, 1))
+  :fun ref value_if_set!: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct_if_set!(0, 2, 1))
 
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(1, 0, 1))
+  :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(1, 0, 1))
 
 :struct CapnProto.Meta.CodeGeneratorRequest.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1428,10 +1701,12 @@
   :const capn_proto_pointer_count U16: 2
 
   :fun ref nodes: CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.list(0))
+  :fun ref nodes_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.list_if_set!(0))
   :fun ref init_nodes(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.init_list(0, 5, 6, new_count))
 
   :fun ref requested_files: CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.list(1))
+  :fun ref requested_files_if_set!: CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_requested_files(new_count)
     CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
 
@@ -1443,12 +1718,15 @@
   :const capn_proto_pointer_count U16: 2
 
   :fun id: @_p.u64(0x0)
+  :fun id_if_set!: @_p.u64_if_set!(0x0)
   :fun ref "id="(new_value): @_p.set_u64(0x0, new_value, 0)
 
   :fun ref filename: @_p.text(0)
+  :fun ref filename_if_set!: @_p.text_if_set!(0)
   :fun ref "filename="(new_value): @_p.set_text(0, new_value, "")
 
   :fun ref imports: CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).from_pointer(@_p.list(1))
+  :fun ref imports_if_set!: CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_imports(new_count)
     CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).from_pointer(@_p.init_list(1, 1, 1, new_count))
 
@@ -1460,7 +1738,9 @@
   :const capn_proto_pointer_count U16: 1
 
   :fun id: @_p.u64(0x0)
+  :fun id_if_set!: @_p.u64_if_set!(0x0)
   :fun ref "id="(new_value): @_p.set_u64(0x0, new_value, 0)
 
   :fun ref name: @_p.text(0)
+  :fun ref name_if_set!: @_p.text_if_set!(0)
   :fun ref "name="(new_value): @_p.set_text(0, new_value, "")

--- a/src/CapnProto.Pointer.Struct.savi
+++ b/src/CapnProto.Pointer.Struct.savi
@@ -141,15 +141,31 @@
 
   :fun bool(n, bit_mask): @u8(n).bit_and(bit_mask) != 0
 
+  :fun u8_if_set!(n)  U8:  value = @_u8!(n),  error! if value.is_zero, value
+  :fun u16_if_set!(n) U16: value = @_u16!(n), error! if value.is_zero, value
+  :fun u32_if_set!(n) U32: value = @_u32!(n), error! if value.is_zero, value
+  :fun u64_if_set!(n) U64: value = @_u64!(n), error! if value.is_zero, value
+
+  :fun i8_if_set!(n): @u8_if_set!(n).i8
+  :fun i16_if_set!(n): @u16_if_set!(n).i16
+  :fun i32_if_set!(n): @u32_if_set!(n).i32
+  :fun i64_if_set!(n): @u64_if_set!(n).i64
+
+  :fun f32_if_set!(n): @u32_if_set!(n).f32
+  :fun f64_if_set!(n): @u64_if_set!(n).f64
+
+  :fun bool_if_set!(n, bit_mask)
+    if (@_u8!(n).bit_and(bit_mask) != 0) (True | error!)
+
   :fun assert_union!(n, value): error! if (@u16(n) != value)
   :fun check_union(n, value): @u16(n) == value
 
-  :fun text(n): try (@_text!(n) | @_empty_text)
+  :fun text(n): try (@text_if_set!(n) | @_empty_text)
   :fun _empty_text
     CapnProto.Text.read_from_pointer(
       CapnProto.Pointer.U8List.empty(@_segment)
     )
-  :fun _text!(n)
+  :fun text_if_set!(n)
     byte_offset = @_ptr_byte_offset!(n)
     CapnProto.Text.read_from_pointer(
       _ParseU8ListPointer._parse!(
@@ -157,10 +173,10 @@
       )
     )
 
-  :fun data(n): try (@_data!(n) | @_empty_data)
+  :fun data(n): try (@data_if_set!(n) | @_empty_data)
   :fun _empty_data
     CapnProto.Data.from_pointer(CapnProto.Pointer.U8List.empty(@_segment))
-  :fun _data!(n)
+  :fun data_if_set!(n)
     byte_offset = @_ptr_byte_offset!(n)
     CapnProto.Data.read_from_pointer(
       _ParseU8ListPointer._parse!(
@@ -168,19 +184,19 @@
       )
     )
 
-  :fun struct(n): try (@_struct!(n) | @_empty_struct)
+  :fun struct(n): try (@struct_if_set!(n) | @_empty_struct)
   :fun _empty_struct
     CapnProto.Pointer.Struct.empty(@_segment)
-  :fun _struct!(n):
+  :fun struct_if_set!(n):
     byte_offset = @_ptr_byte_offset!(n)
     _ParseStructPointer._parse!(
       @_segment, byte_offset, @_segment._u64!(byte_offset)
     )
 
-  :fun list(n): try (@_list!(n) | @_empty_list)
+  :fun list(n): try (@list_if_set!(n) | @_empty_list)
   :fun _empty_list
     CapnProto.Pointer.StructList.empty(@_segment)
-  :fun _list!(n):
+  :fun list_if_set!(n):
     byte_offset = @_ptr_byte_offset!(n)
     _ParseStructListPointer._parse!(
       @_segment, byte_offset, @_segment._u64!(byte_offset)
@@ -264,6 +280,22 @@
 
   :fun bool(n, bit_mask): @u8(n).bit_and(bit_mask) != 0
 
+  :fun u8_if_set!(n)  U8:  value = @_u8!(n),  error! if value.is_zero, value
+  :fun u16_if_set!(n) U16: value = @_u16!(n), error! if value.is_zero, value
+  :fun u32_if_set!(n) U32: value = @_u32!(n), error! if value.is_zero, value
+  :fun u64_if_set!(n) U64: value = @_u64!(n), error! if value.is_zero, value
+
+  :fun i8_if_set!(n): @u8_if_set!(n).i8
+  :fun i16_if_set!(n): @u16_if_set!(n).i16
+  :fun i32_if_set!(n): @u32_if_set!(n).i32
+  :fun i64_if_set!(n): @u64_if_set!(n).i64
+
+  :fun f32_if_set!(n): @u32_if_set!(n).f32
+  :fun f64_if_set!(n): @u64_if_set!(n).f64
+
+  :fun bool_if_set!(n, bit_mask)
+    if (@_u8!(n).bit_and(bit_mask) != 0) (True | error!)
+
   :fun ref set_u8(n, v U8, d U8): try @_set_u8!(n, v.bit_xor(d)), v
   :fun ref set_u16(n, v U16, d U16): try @_set_u16!(n, v.bit_xor(d)), v
   :fun ref set_u32(n, v U32, d U32): try @_set_u32!(n, v.bit_xor(d)), v
@@ -298,12 +330,12 @@
   :fun check_union(n, value): @u16(n) == value
   :fun ref mark_union(n, value): try @_set_u16!(n, value), @
 
-  :fun ref text(n): try (@_text!(n) | @_empty_text)
+  :fun ref text(n): try (@text_if_set!(n) | @_empty_text)
   :fun ref _empty_text
     CapnProto.Text.from_pointer(
       CapnProto.Pointer.U8List.empty(@_segment)
     )
-  :fun ref _text!(n)
+  :fun ref text_if_set!(n)
     byte_offset = @_ptr_byte_offset!(n)
     CapnProto.Text.from_pointer(
       _ParseU8ListPointer._parse_builder!(
@@ -341,10 +373,10 @@
 
     new_text
 
-  :fun ref data(n): try (@_data!(n) | @_empty_data)
+  :fun ref data(n): try (@data_if_set!(n) | @_empty_data)
   :fun ref _empty_data
     CapnProto.Data.from_pointer(CapnProto.Pointer.U8List.empty(@_segment))
-  :fun ref _data!(n)
+  :fun ref data_if_set!(n)
     byte_offset = @_ptr_byte_offset!(n)
     CapnProto.Data.from_pointer(
       _ParseU8ListPointer._parse_builder!(
@@ -385,6 +417,16 @@
   :fun ref _empty_struct
     CapnProto.Pointer.Struct.Builder.empty(@_segment)
 
+  :fun ref struct_if_set!(
+    n U16
+    data_word_count U16
+    pointer_count U16
+  ) CapnProto.Pointer.Struct.Builder
+    byte_offset = @_ptr_byte_offset!(n)
+    _ParseStructPointer._parse_builder!(
+      @_segment, byte_offset, @_segment._u64!(byte_offset)
+    )
+
   :fun ref struct(
     n U16
     data_word_count U16
@@ -415,10 +457,10 @@
 
     new_pointer
 
-  :fun ref list(n): try (@_list!(n) | @_empty_list)
+  :fun ref list(n): try (@list_if_set!(n) | @_empty_list)
   :fun ref _empty_list
     CapnProto.Pointer.StructList.Builder.empty(@_segment)
-  :fun ref _list!(n):
+  :fun ref list_if_set!(n):
     byte_offset = @_ptr_byte_offset!(n)
     _ParseStructListPointer._parse_builder!(
       @_segment, byte_offset, @_segment._u64!(byte_offset)

--- a/src/capnpc-savi/_Gen.savi
+++ b/src/capnpc-savi/_Gen.savi
@@ -213,6 +213,7 @@
       @_out << "\n"
       try @_emit_field_check_union_method!(node, field)
       @_emit_field_getter(node, field, is_builder)
+      @_emit_field_getter_if_set(node, field, is_builder)
       if is_builder (
         try @_emit_field_setter!(node, field)
       )
@@ -254,7 +255,23 @@
       try @_emit_field_check_union!(node, field, True)
       @_out << ", "
     )
-    @_emit_field_get_expr(field, is_builder)
+    @_emit_field_get_expr(field, is_builder, False)
+
+  :fun ref _emit_field_getter_if_set(
+    node CapnProto.Meta.Node
+    field CapnProto.Meta.Field
+    is_builder Bool
+  )
+    is_union = field.discriminant_value != field.no_discriminant
+    needs_ref = is_builder && try (@_is_pointer_type(field.slot!.type) | True)
+    @_out << "\n  :fun\(
+      if needs_ref " ref"
+    ) \(_TextCase.Snake[field.name])_if_set!: "
+    if is_union (
+      try @_emit_field_check_union!(node, field, True)
+      @_out << ", "
+    )
+    @_emit_field_get_expr(field, is_builder, True)
 
   :fun ref _emit_field_setter!(
     node CapnProto.Meta.Node
@@ -354,7 +371,7 @@
     ))"
 
     @_out << "\n    "
-    @_emit_field_get_expr(field, True)
+    @_emit_field_get_expr(field, True, False)
 
   :fun ref _emit_field_check_union_method!(
     node CapnProto.Meta.Node
@@ -382,7 +399,13 @@
       field.discriminant_value
     ))"
 
-  :fun ref _emit_field_get_expr(field CapnProto.Meta.Field, is_builder Bool)
+  :fun ref _emit_field_get_expr(
+    field CapnProto.Meta.Field
+    is_builder Bool
+    is_get_if_set Bool
+  )
+    suffix = if is_get_if_set ("_if_set!" | "")
+
     // First, handle the case where the field is a group instead of a slot.
     try (
       type_id = field.group!.type_id
@@ -406,7 +429,7 @@
     | type.is_void |
       @_out << "None"
     | type.is_bool |
-      @_out << "@_p.bool(\(
+      @_out << "@_p.bool\(suffix)(\(
         (offset / 8).format.hex.without_leading_zeros
       ), \(
         U8[1].bit_shl((offset % 8).u8).format.binary
@@ -417,84 +440,84 @@
         )
       )
     | type.is_int8 |
-      @_out << "@_p.i8(\((offset * 1).format.hex.without_leading_zeros))"
+      @_out << "@_p.i8\(suffix)(\((offset * 1).format.hex.without_leading_zeros))"
       try (
         if (slot.default_value.int8! != 0) (
           @_out << ".bit_xor(\(slot.default_value.int8!))"
         )
       )
     | type.is_int16 |
-      @_out << "@_p.i16(\((offset * 2).format.hex.without_leading_zeros))"
+      @_out << "@_p.i16\(suffix)(\((offset * 2).format.hex.without_leading_zeros))"
       try (
         if (slot.default_value.int16! != 0) (
           @_out << ".bit_xor(\(slot.default_value.int16!))"
         )
       )
     | type.is_int32 |
-      @_out << "@_p.i32(\((offset * 4).format.hex.without_leading_zeros))"
+      @_out << "@_p.i32\(suffix)(\((offset * 4).format.hex.without_leading_zeros))"
       try (
         if (slot.default_value.int32! != 0) (
           @_out << ".bit_xor(\(slot.default_value.int32!))"
         )
       )
     | type.is_int64 |
-      @_out << "@_p.i64(\((offset * 8).format.hex.without_leading_zeros))"
+      @_out << "@_p.i64\(suffix)(\((offset * 8).format.hex.without_leading_zeros))"
       try (
         if (slot.default_value.int64! != 0) (
           @_out << ".bit_xor(\(slot.default_value.int64!))"
         )
       )
     | type.is_uint8 |
-      @_out << "@_p.u8(\((offset * 1).format.hex.without_leading_zeros))"
+      @_out << "@_p.u8\(suffix)(\((offset * 1).format.hex.without_leading_zeros))"
       try (
         if (slot.default_value.uint8! != 0) (
           @_out << ".bit_xor(\(slot.default_value.uint8!))"
         )
       )
     | type.is_uint16 |
-      @_out << "@_p.u16(\((offset * 2).format.hex.without_leading_zeros))"
+      @_out << "@_p.u16\(suffix)(\((offset * 2).format.hex.without_leading_zeros))"
       try (
         if (slot.default_value.uint16! != 0) (
           @_out << ".bit_xor(\(slot.default_value.uint16!))"
         )
       )
     | type.is_uint32 |
-      @_out << "@_p.u32(\((offset * 4).format.hex.without_leading_zeros))"
+      @_out << "@_p.u32\(suffix)(\((offset * 4).format.hex.without_leading_zeros))"
       try (
         if (slot.default_value.uint32! != 0) (
           @_out << ".bit_xor(\(slot.default_value.uint32!))"
         )
       )
     | type.is_uint64 |
-      @_out << "@_p.u64(\((offset * 8).format.hex.without_leading_zeros))"
+      @_out << "@_p.u64\(suffix)(\((offset * 8).format.hex.without_leading_zeros))"
       try (
         if (slot.default_value.uint64! != 0) (
           @_out << ".bit_xor(\(slot.default_value.uint64!))"
         )
       )
     | type.is_float32 |
-      @_out << "@_p.f32(\((offset * 4).format.hex.without_leading_zeros))"
+      @_out << "@_p.f32\(suffix)(\((offset * 4).format.hex.without_leading_zeros))"
       try (
         if (slot.default_value.float32! != 0) (
           @_out << " // UNHANDLED: default_value"
         )
       )
     | type.is_float64 |
-      @_out << "@_p.f64(\((offset * 8).format.hex.without_leading_zeros))"
+      @_out << "@_p.f64\(suffix)(\((offset * 8).format.hex.without_leading_zeros))"
       try (
         if (slot.default_value.float64! != 0) (
           @_out << " // UNHANDLED: default_value"
         )
       )
     | type.is_text |
-      @_out << "@_p.text(\(offset))"
+      @_out << "@_p.text\(suffix)(\(offset))"
       try (
         if (slot.default_value.text!.size > 0) (
           @_out << " // UNHANDLED: default_value"
         )
       )
     | type.is_data |
-      @_out << "@_p.data(\(offset))"
+      @_out << "@_p.data\(suffix)(\(offset))"
     //   TODO: Handle default value:
     //   try (
     //     if (slot.default_value.data!.size > 0) (
@@ -505,10 +528,10 @@
       // TODO: handle default list values
       @_out << "\(@_type_name(type, is_builder)).\(
         if is_builder ("" | "read_")
-      )from_pointer(@_p.list(\(offset)))"
+      )from_pointer(@_p.list\(suffix)(\(offset)))"
     | type.is_enum |
       @_out << "\(@_type_name(type, is_builder))._new("
-      @_out << "@_p.u16(\((offset * 2).format.hex.without_leading_zeros))"
+      @_out << "@_p.u16\(suffix)(\((offset * 2).format.hex.without_leading_zeros))"
       try (
         if (slot.default_value.uint16! != 0) (
           @_out << ".bit_xor(\(slot.default_value.uint16!))"
@@ -522,7 +545,7 @@
 
         @_out << "\(@_type_name(type, is_builder)).\(
           if is_builder ("" | "read_")
-        )from_pointer(@_p.struct(\(offset)\(
+        )from_pointer(@_p.struct\(suffix)(\(offset)\(
           if is_builder ", \(struct.data_word_count), \(struct.pointer_count)"
         )))"
       )


### PR DESCRIPTION
These will raise an error if the value has not been set, or if it has been set to its default value.

This will be useful in tracing for printing, so that we can show an abbreviated representation for objects where only some properties have been given non-default values.