### PR TITLE
Fix conversion of floating-point values for encoding.

### DIFF
--- a/spec/CapnProto.Message.Builder.Spec.savi
+++ b/spec/CapnProto.Message.Builder.Spec.savi
@@ -83,7 +83,7 @@
 
   :const capn_proto_data_word_count U16: 7
   :fun some_u64: @_p.u64(0x20)
-  :fun some_u32: @_p.u64(0x28)
+  :fun some_u32: @_p.u32(0x28)
   :fun ref "some_u64="(new_value): @_p.set_u64(0x20, new_value, 0)
   :fun ref "some_u32="(new_value): @_p.set_u32(0x28, new_value, 0)
 
@@ -97,7 +97,7 @@
 
   :const capn_proto_data_word_count U16: 7
   :fun some_f64: @_p.f64(0x20)
-  :fun some_f32: @_p.f64(0x28)
+  :fun some_f32: @_p.f32(0x28)
   :fun ref "some_f64="(new_value): @_p.set_f64(0x20, new_value, 0)
   :fun ref "some_f32="(new_value): @_p.set_f32(0x28, new_value, 0)
 
@@ -215,8 +215,8 @@
     assert: root.is_foo.is_false
     assert: root.is_bar.is_true
 
-    assert: bar.some_f64 == 0, bar.some_f64 = 42, assert: bar.some_f64 == 42
-    assert: bar.some_f32 == 0, bar.some_f32 = 43, assert: bar.some_f32 == 43
+    assert: bar.some_f64 == 0, bar.some_f64 = 42.2, assert: bar.some_f64 == 42.2
+    assert: bar.some_f32 == 0, bar.some_f32 = 43.3, assert: bar.some_f32 == 43.3
     assert: "\(bar.blob)" == "", bar.blob = b"!!", assert: "\(bar.blob)" == "!!"
 
   :it "lets you take the resulting byte buffers"

--- a/src/CapnProto.Pointer.Struct.savi
+++ b/src/CapnProto.Pointer.Struct.savi
@@ -138,8 +138,8 @@
   :fun i32(n): @u32(n).i32
   :fun i64(n): @u64(n).i64
 
-  :fun f32(n): @u32(n).f32
-  :fun f64(n): @u64(n).f64
+  :fun f32(n): F32.from_bits(@u32(n))
+  :fun f64(n): F64.from_bits(@u64(n))
 
   :fun bool(n, bit_mask): @u8(n).bit_and(bit_mask) != 0
 
@@ -153,8 +153,8 @@
   :fun i32_if_set!(n): @u32_if_set!(n).i32
   :fun i64_if_set!(n): @u64_if_set!(n).i64
 
-  :fun f32_if_set!(n): @u32_if_set!(n).f32
-  :fun f64_if_set!(n): @u64_if_set!(n).f64
+  :fun f32_if_set!(n): F32.from_bits(@u32_if_set!(n))
+  :fun f64_if_set!(n): F64.from_bits(@u64_if_set!(n))
 
   :fun bool_if_set!(n, bit_mask)
     if (@_u8!(n).bit_and(bit_mask) != 0) (True | error!)
@@ -285,8 +285,8 @@
   :fun i32(n): @u32(n).i32
   :fun i64(n): @u64(n).i64
 
-  :fun f32(n): @u32(n).f32
-  :fun f64(n): @u64(n).f64
+  :fun f32(n): F32.from_bits(@u32(n))
+  :fun f64(n): F64.from_bits(@u64(n))
 
   :fun bool(n, bit_mask): @u8(n).bit_and(bit_mask) != 0
 
@@ -300,8 +300,8 @@
   :fun i32_if_set!(n): @u32_if_set!(n).i32
   :fun i64_if_set!(n): @u64_if_set!(n).i64
 
-  :fun f32_if_set!(n): @u32_if_set!(n).f32
-  :fun f64_if_set!(n): @u64_if_set!(n).f64
+  :fun f32_if_set!(n): F32.from_bits(@u32_if_set!(n))
+  :fun f64_if_set!(n): F64.from_bits(@u64_if_set!(n))
 
   :fun bool_if_set!(n, bit_mask)
     if (@_u8!(n).bit_and(bit_mask) != 0) (True | error!)
@@ -316,8 +316,8 @@
   :fun ref set_i32(n, v I32, d I32): @set_u32(n, v.u32, d.u32), v
   :fun ref set_i64(n, v I64, d I64): @set_u64(n, v.u64, d.u64), v
 
-  :fun ref set_f32(n, v F32, d F32): @set_u32(n, v.u32, d.u32), v
-  :fun ref set_f64(n, v F64, d F64): @set_u64(n, v.u64, d.u64), v
+  :fun ref set_f32(n, v F32, d F32): @set_u32(n, v.bits, d.bits), v
+  :fun ref set_f64(n, v F64, d F64): @set_u64(n, v.bits, d.bits), v
 
   :fun ref set_bool(n, bit_mask, value Bool)
     if value (


### PR DESCRIPTION
Prior to this commit, the internal conversion process was using value-based conversion, which tried to convert from and to the same numeric value as the internal integers used to encode.

Instead, we need to encode using integers that correspond to the bitwise representation of the floating-point values, so that we have a lossless conversion to and from.