### PR TITLE
Add `trim_` methods for `CapnProto.List` fields.

### DIFF
--- a/spec/CapnProto.Message.Builder.Spec.savi
+++ b/spec/CapnProto.Message.Builder.Spec.savi
@@ -44,6 +44,7 @@
   :fun ref children: CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.list(3))
   :fun ref children_if_set!: CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.list_if_set!(3))
   :fun ref init_children(new_count): CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.init_list(3, 2, 1, new_count))
+  :fun ref trim_children(new_start, new_finish): CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.trim_list(3, 2, 1, new_start, new_finish))
 
   :fun is_foo: @_p.check_union(0x30, 0)
   :fun ref foo!: @_p.assert_union!(0x30, 0), _ExampleAsFooBuilder.from_pointer(@_p)
@@ -185,6 +186,20 @@
     assert: (children[2]!.a = 55, children[2]!.a == 55)
     assert: (children[2]!.b = 66, children[2]!.b == 66)
     assert: (children[2]!.name = "baz", "\(children[2]!.name)" == "baz")
+
+    children = root.trim_children(0, 3)
+    assert: children.size == 3
+    children = root.trim_children(0, 999)
+    assert: children.size == 3
+    children = root.trim_children(1, 2)
+    assert: children.size == 1
+    children = root.children
+    assert: children.size == 1
+    assert: children[0]!.a == 33
+    assert: children[0]!.b == 44
+    assert: "\(children[0]!.name)" == "bar"
+    children = root.trim_children(999, 0)
+    assert: children.size == 0
 
     assert: root.init_children(1000).size == 1000
     assert: root.children[0]!.a == 0

--- a/src/CapnProto.Meta.capnp.savi
+++ b/src/CapnProto.Meta.capnp.savi
@@ -1058,11 +1058,15 @@
   :fun ref nested_nodes_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_nested_nodes(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).from_pointer(@_p.init_list(1, 1, 1, new_count))
+  :fun ref trim_nested_nodes(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).from_pointer(@_p.trim_list(1, 1, 1, new_start, new_finish))
 
   :fun ref annotations: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list(2))
   :fun ref annotations_if_set!: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list_if_set!(2))
   :fun ref init_annotations(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(2, 1, 2, new_count))
+  :fun ref trim_annotations(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.trim_list(2, 1, 2, new_start, new_finish))
 
   :fun is_file: @_p.check_union(0xc, 0)
   :fun file!: @_p.assert_union!(0xc, 0), None
@@ -1135,6 +1139,8 @@
   :fun ref parameters_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list_if_set!(5))
   :fun ref init_parameters(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.init_list(5, 0, 1, new_count))
+  :fun ref trim_parameters(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.trim_list(5, 0, 1, new_start, new_finish))
 
   :fun is_generic: @_p.bool(0x24, 0b00000001)
   :fun is_generic_if_set!: @_p.bool_if_set!(0x24, 0b00000001)
@@ -1180,6 +1186,8 @@
   :fun ref fields_if_set!: CapnProto.List.Builder(CapnProto.Meta.Field.Builder).from_pointer(@_p.list_if_set!(3))
   :fun ref init_fields(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Field.Builder).from_pointer(@_p.init_list(3, 3, 4, new_count))
+  :fun ref trim_fields(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.Field.Builder).from_pointer(@_p.trim_list(3, 3, 4, new_start, new_finish))
 
 :struct CapnProto.Meta.Node.AS_enum.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1197,6 +1205,8 @@
   :fun ref enumerants_if_set!: CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.list_if_set!(3))
   :fun ref init_enumerants(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.init_list(3, 1, 2, new_count))
+  :fun ref trim_enumerants(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.trim_list(3, 1, 2, new_start, new_finish))
 
 :struct CapnProto.Meta.Node.AS_interface.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1214,11 +1224,15 @@
   :fun ref methods_if_set!: CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.list_if_set!(3))
   :fun ref init_methods(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.init_list(3, 3, 5, new_count))
+  :fun ref trim_methods(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.trim_list(3, 3, 5, new_start, new_finish))
 
   :fun ref superclasses: CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.list(4))
   :fun ref superclasses_if_set!: CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.list_if_set!(4))
   :fun ref init_superclasses(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.init_list(4, 1, 1, new_count))
+  :fun ref trim_superclasses(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.trim_list(4, 1, 1, new_start, new_finish))
 
 :struct CapnProto.Meta.Node.AS_const.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1363,6 +1377,8 @@
   :fun ref annotations_if_set!: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_annotations(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
+  :fun ref trim_annotations(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.trim_list(1, 1, 2, new_start, new_finish))
 
   :fun discriminant_value: @_p.u16(0x2).bit_xor(65535)
   :fun discriminant_value_if_set!: @_p.u16_if_set!(0x2).bit_xor(65535)
@@ -1483,6 +1499,8 @@
   :fun ref annotations_if_set!: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_annotations(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
+  :fun ref trim_annotations(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.trim_list(1, 1, 2, new_start, new_finish))
 
 :struct CapnProto.Meta.Superclass.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1535,6 +1553,8 @@
   :fun ref annotations_if_set!: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_annotations(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
+  :fun ref trim_annotations(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.trim_list(1, 1, 2, new_start, new_finish))
 
   :fun ref param_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(2, 0, 1))
   :fun ref param_brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(2, 0, 1))
@@ -1546,6 +1566,8 @@
   :fun ref implicit_parameters_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list_if_set!(4))
   :fun ref init_implicit_parameters(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.init_list(4, 0, 1, new_count))
+  :fun ref trim_implicit_parameters(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.trim_list(4, 0, 1, new_start, new_finish))
 
 :struct CapnProto.Meta.Type.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1899,6 +1921,8 @@
   :fun ref scopes_if_set!: CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.list_if_set!(0))
   :fun ref init_scopes(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.init_list(0, 2, 1, new_count))
+  :fun ref trim_scopes(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.trim_list(0, 2, 1, new_start, new_finish))
 
 :struct CapnProto.Meta.Brand.Scope.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -2154,11 +2178,15 @@
   :fun ref nodes_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.list_if_set!(0))
   :fun ref init_nodes(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.init_list(0, 5, 6, new_count))
+  :fun ref trim_nodes(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.trim_list(0, 5, 6, new_start, new_finish))
 
   :fun ref requested_files: CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.list(1))
   :fun ref requested_files_if_set!: CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_requested_files(new_count)
     CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
+  :fun ref trim_requested_files(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.trim_list(1, 1, 2, new_start, new_finish))
 
 :struct CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -2184,6 +2212,8 @@
   :fun ref imports_if_set!: CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_imports(new_count)
     CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).from_pointer(@_p.init_list(1, 1, 1, new_count))
+  :fun ref trim_imports(new_start, new_finish)
+    CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).from_pointer(@_p.trim_list(1, 1, 1, new_start, new_finish))
 
 :struct CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder
   :let _p CapnProto.Pointer.Struct.Builder

--- a/src/CapnProto.Pointer.Struct.savi
+++ b/src/CapnProto.Pointer.Struct.savi
@@ -510,3 +510,48 @@
     )
 
     new_pointer
+
+  :fun ref trim_list(
+    n U16
+    data_word_count U16
+    pointer_count U16
+    new_list_start USize
+    new_list_finish USize
+  ) CapnProto.Pointer.StructList.Builder
+
+    // We expect the byte offset to be within bounds - otherwise we can't do it,
+    // and we'll return an empty list builder to signal this problem.
+    byte_offset = try (@_ptr_byte_offset!(n) | return @_empty_list)
+
+    // If there's no existing list pointer (or if an empty list was requested)
+    // follow the same logic as init_list.
+    pointer = try (
+      _ParseStructListPointer._parse_builder!(
+        @_segment, byte_offset, @_segment._u64!(byte_offset)
+      )
+    |
+      new_list_finish = new_list_finish.at_least(new_list_start)
+      new_list_count = new_list_finish - new_list_start
+      return @init_list(n, data_word_count, pointer_count, new_list_count)
+    )
+
+    // Clip the parameters. If they end up empty, init an zero-length list.
+    new_list_finish = new_list_finish.at_most(pointer._list_count.usize)
+    new_list_start = new_list_start.at_most(new_list_finish)
+    if (new_list_finish == new_list_start) (
+      return @init_list(n, data_word_count, pointer_count, 0)
+    )
+
+    // Get a trimmed pointer (which also frees the gaps on each side)
+    pointer = pointer._trim(
+      new_list_start.u32
+      pointer._list_count - new_list_finish.u32
+    )
+
+    // We need to write the pointer to the buffer so it can be followed.
+    try @_segment._set_u64!(
+      byte_offset
+      _WriteStructListPointer._encode(byte_offset, pointer)
+    )
+
+    pointer

--- a/src/CapnProto.Pointer.StructList.savi
+++ b/src/CapnProto.Pointer.StructList.savi
@@ -219,6 +219,40 @@
     @_byte_offset = byte_offset + 8
     try @_segment._set_u64!(byte_offset, _WriteStructListPointer._encode_tag(@))
 
+  :fun ref _trim(trim_left U32, trim_right U32)
+    // Create the new, trimmed pointer.
+    added_byte_offset = @_element_byte_size * trim_left
+    byte_offset = @_byte_offset + added_byte_offset
+    list_count = @_list_count - trim_left - trim_right
+    new_pointer = @_new(
+      @_segment, byte_offset
+      list_count, @_data_word_count, @_pointer_count
+    )
+
+    // Free the bytes to the right, if applicable.
+    if trim_right.is_nonzero (
+      @_segment._free_pointer(
+        byte_offset + @_element_byte_size * list_count
+        @_element_byte_size * trim_right
+      )
+    )
+
+    // Free the bytes to the left, if applicable.
+    if trim_left.is_nonzero (
+      @_segment._free_pointer(
+        byte_offset - 8 - added_byte_offset
+        added_byte_offset
+      )
+    )
+
+    // Re-encode the tag byte.
+    try @_segment._set_u64!(
+      byte_offset - 8
+      _WriteStructListPointer._encode_tag(new_pointer)
+    )
+
+    new_pointer
+
   :fun ref _reallocate(new_count U32)
     try (
       element_byte_size = @_element_byte_size

--- a/src/capnpc-savi/_Gen.savi
+++ b/src/capnpc-savi/_Gen.savi
@@ -227,11 +227,8 @@
       @_emit_field_getter_if_set(node, field, is_builder)
       if is_builder (
         try @_emit_field_setter!(node, field)
-      )
-      if is_builder (
         try @_emit_field_list_initter!(node, field)
-      )
-      if is_builder (
+        try @_emit_field_list_trimmer!(node, field)
         try @_emit_field_union_initter!(node, field)
       )
     )
@@ -361,6 +358,33 @@
     ), \(
       struct.pointer_count
     ), new_count))"
+
+  :fun ref _emit_field_list_trimmer!(
+    node CapnProto.Meta.Node
+    field CapnProto.Meta.Field
+  )
+    is_union = field.discriminant_value != field.no_discriminant
+    error! if is_union // TODO: implement for union-lists
+
+    slot = field.slot!
+    type = slot.type
+
+    struct_type = type.list!.element_type.struct!
+    struct = @_find_node!(struct_type.type_id).struct!
+
+    @_out << "\n  :fun ref trim_\(
+      _TextCase.Snake[field.name]
+    )(new_start, new_finish)"
+
+    @_out << "\n    \(
+      @_type_name(type, True)
+    ).from_pointer(@_p.trim_list(\(
+      slot.offset
+    ), \(
+      struct.data_word_count
+    ), \(
+      struct.pointer_count
+    ), new_start, new_finish))"
 
   :fun ref _emit_field_union_initter!(
     node CapnProto.Meta.Node


### PR DESCRIPTION
This allows truncating the front or back of a list field, freeing some memory from the head and/or tail, or freeing the entire memory for the list if the new list count is zero.

There is no copying or moving of memory - list data stays at the same address in the segment and it just leaves holes at the head or tail suitable for future allocations that may fit in that space.