### PR TITLE
Add `capn_proto_address` to pointers and generated wrapping code.

### DIFF
--- a/src/CapnProto.Meta.capnp.savi
+++ b/src/CapnProto.Meta.capnp.savi
@@ -8,6 +8,7 @@
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -82,6 +83,7 @@
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -122,6 +124,7 @@
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -138,6 +141,7 @@
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -158,6 +162,7 @@
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -178,6 +183,7 @@
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -242,6 +248,7 @@
 
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -258,6 +265,7 @@
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -278,6 +286,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :const no_discriminant U16: 65535
 
@@ -322,6 +331,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -350,6 +360,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -366,6 +377,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -388,6 +400,7 @@
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -412,6 +425,7 @@
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -432,6 +446,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 5
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -476,6 +491,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -583,6 +599,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -599,6 +616,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -619,6 +637,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -639,6 +658,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -659,6 +679,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -686,6 +707,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -718,6 +740,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -738,6 +761,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -754,6 +778,7 @@
 
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -770,6 +795,7 @@
 
   :const capn_proto_data_word_count U16: 2
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -796,6 +822,7 @@
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -818,6 +845,7 @@
 
   :const capn_proto_data_word_count U16: 2
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -925,6 +953,7 @@
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -968,6 +997,7 @@
 
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 2
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -988,6 +1018,7 @@
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1012,6 +1043,7 @@
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1033,6 +1065,7 @@
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1153,6 +1186,7 @@
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1196,6 +1230,7 @@
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1215,6 +1250,7 @@
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1241,6 +1277,7 @@
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1259,6 +1296,7 @@
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1322,6 +1360,7 @@
 
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1338,6 +1377,7 @@
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1358,6 +1398,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :const no_discriminant U16: 65535
 
@@ -1413,6 +1454,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1439,6 +1481,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1455,6 +1498,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1482,6 +1526,7 @@
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1509,6 +1554,7 @@
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1528,6 +1574,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 5
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1576,6 +1623,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1728,6 +1776,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1743,6 +1792,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1762,6 +1812,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1781,6 +1832,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1800,6 +1852,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1836,6 +1889,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1876,6 +1930,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1896,6 +1951,7 @@
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1912,6 +1968,7 @@
 
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1931,6 +1988,7 @@
 
   :const capn_proto_data_word_count U16: 2
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1961,6 +2019,7 @@
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1988,6 +2047,7 @@
 
   :const capn_proto_data_word_count U16: 2
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2147,6 +2207,7 @@
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2169,6 +2230,7 @@
 
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 2
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2195,6 +2257,7 @@
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2222,6 +2285,7 @@
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)

--- a/src/CapnProto.Pointer.Struct.savi
+++ b/src/CapnProto.Pointer.Struct.savi
@@ -59,7 +59,7 @@
   :fun _parse_builder!(segment CapnProto.Segment, current_offset, value)
     read_ptr = @_parse!(segment, current_offset, value)
     if read_ptr._segment !== segment (
-      try (segment = segment._segments._list[read_ptr._segment._index]!)
+      try (segment = segment._segments._list[read_ptr._segment.index]!)
     )
     CapnProto.Pointer.Struct.Builder._new(
       segment, read_ptr._byte_offset
@@ -106,6 +106,7 @@
     @_data_word_count = 0
     @_pointer_count = 0
 
+  :fun capn_proto_address: @_byte_offset.u64.bit_or(@_segment.index.u64.bit_shl(32))
   :fun absolute_address: @_segment._bytes.cpointer.address + @_byte_offset.usize
 
   :fun _ptr_byte_offset!(n U16)
@@ -231,6 +232,7 @@
 
   :fun ref _free: @_segment._free_pointer(@_byte_offset, @_total_byte_size), @
 
+  :fun capn_proto_address: @_byte_offset.u64.bit_or(@_segment.index.u64.bit_shl(32))
   :fun absolute_address: @_segment._bytes.cpointer.address + @_byte_offset.usize
 
   :fun as_reader:

--- a/src/CapnProto.Pointer.StructList.savi
+++ b/src/CapnProto.Pointer.StructList.savi
@@ -96,7 +96,7 @@
   )
     read_ptr = @_parse!(segment, current_offset, value)
     if read_ptr._segment !== segment (
-      try (segment = segment._segments._list[read_ptr._segment._index]!)
+      try (segment = segment._segments._list[read_ptr._segment.index]!)
     )
     CapnProto.Pointer.StructList.Builder._new(
       segment, read_ptr._byte_offset
@@ -160,6 +160,7 @@
     @_data_word_count = 0
     @_pointer_count = 0
 
+  :fun capn_proto_address: @_byte_offset.u64.bit_or(@_segment.index.u64.bit_shl(32))
   :fun absolute_address: @_segment._bytes.cpointer.address + @_byte_offset.usize
 
   :fun _element_byte_size: (@_data_word_count.u32 + @_pointer_count.u32) * 8
@@ -195,6 +196,7 @@
     @_list_count, @_data_word_count, @_pointer_count
   )
 
+  :fun capn_proto_address: @_byte_offset.u64.bit_or(@_segment.index.u64.bit_shl(32))
   :fun absolute_address: @_segment._bytes.cpointer.address + @_byte_offset.usize
 
   :new empty(@_segment)

--- a/src/CapnProto.Pointer.U8List.savi
+++ b/src/CapnProto.Pointer.U8List.savi
@@ -77,7 +77,7 @@
   :fun _parse_builder!(segment CapnProto.Segment, current_offset, value)
     read_ptr = @_parse!(segment, current_offset, value)
     if read_ptr._segment !== segment (
-      try (segment = segment._segments._list[read_ptr._segment._index]!)
+      try (segment = segment._segments._list[read_ptr._segment.index]!)
     )
     CapnProto.Pointer.U8List._new_read(
       segment, read_ptr._byte_offset, read_ptr._byte_count
@@ -125,6 +125,8 @@
   :new box empty(@_segment)
     @_byte_offset = 0
     @_byte_count = 0
+
+  :fun capn_proto_address: @_byte_offset.u64.bit_or(@_segment.index.u64.bit_shl(32))
 
   :fun _free(segment CapnProto.Segment)
     if segment === @_segment (

--- a/src/CapnProto.Segment.savi
+++ b/src/CapnProto.Segment.savi
@@ -2,17 +2,19 @@
   :let _segments CapnProto.Segments
   :let _bytes Bytes'ref
   :let _holes Array(Pair(U32))
-  :let _index USize
+
+  :: Within the list of segments, this segment's index (starting from zero).
+  :let index USize
 
   :new new_from_bytes(@_segments, @_bytes, @_holes = [])
-    @_index = @_segments._list.size
+    @index = @_segments._list.size
     @_segments._list << @
 
   :new (@_segments, space USize)
     @_bytes = Bytes.new(space)
     @_bytes.fill_with_zeros(0, @_bytes.space)
     @_holes = [Pair(U32).new(0, space.u32)]
-    @_index = @_segments._list.size
+    @index = @_segments._list.size
     @_segments._list << @
 
   :fun _u8!(offset U32): @_bytes[offset.usize]!

--- a/src/capnpc-savi/_Gen.savi
+++ b/src/capnpc-savi/_Gen.savi
@@ -199,6 +199,7 @@
       @_out << "\n  :const capn_proto_pointer_count U16: \(
         struct.pointer_count
       )"
+      @_out << "\n  :fun capn_proto_address U64: @_p.capn_proto_address"
     )
 
     // Emit constant values.


### PR DESCRIPTION
This address is based on where the pointer is located within the message (deterministically from the position in the list of segments). That is, every time a given message is loaded, the `capn_proto_address` for a given pointer within it will be the same. And the addresses are unique (no two different pointers share the same address, even if they are at the same offset in different segments).

Therefore, this address can be used to uniquely identify parts of a message in a stable way across different loads of the same message.

We will use this in the Savi self-hosted compiler to track addresses of AST nodes, within analysis dumps that refer to those nodes.