### PR TITLE
Add "set struct to point to existing" for child structs of builders.

### DIFF
--- a/spec/CapnProto.Message.Builder.Spec.savi
+++ b/spec/CapnProto.Message.Builder.Spec.savi
@@ -4,6 +4,8 @@
   :let _p CapnProto.Pointer.Struct.Builder
   :new from_pointer(@_p)
 
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
   :const capn_proto_data_word_count U16: 7
   :fun some_u64: @_p.u64(0x0)
   :fun some_i64: @_p.i64(0x8)
@@ -38,13 +40,14 @@
   :fun ref "some_text="(new_value): @_p.set_text(0, new_value, "")
   :fun ref "some_data="(new_value): @_p.set_data(1, new_value, b"")
 
-  :fun ref child: _ExampleChildBuilder.from_pointer(@_p.struct(2, 2, 1))
-  :fun ref child_if_set!: _ExampleChildBuilder.from_pointer(@_p.struct_if_set!(2, 2, 1))
+  :fun ref child: _ExampleChildBuilder.from_pointer(@_p.struct(2, 2, 2))
+  :fun ref child_if_set!: _ExampleChildBuilder.from_pointer(@_p.struct_if_set!(2, 2, 2))
+  :fun ref set_child_to_point_to_existing(existing _ExampleChildBuilder): _ExampleChildBuilder.from_pointer(@_p.set_struct_to_point_to_existing(2, existing._p))
 
   :fun ref children: CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.list(3))
   :fun ref children_if_set!: CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.list_if_set!(3))
-  :fun ref init_children(new_count): CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.init_list(3, 2, 1, new_count))
-  :fun ref trim_children(new_start, new_finish): CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.trim_list(3, 2, 1, new_start, new_finish))
+  :fun ref init_children(new_count): CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.init_list(3, 2, 2, new_count))
+  :fun ref trim_children(new_start, new_finish): CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.trim_list(3, 2, 2, new_start, new_finish))
 
   :fun is_foo: @_p.check_union(0x30, 0)
   :fun ref foo!: @_p.assert_union!(0x30, 0), _ExampleAsFooBuilder.from_pointer(@_p)
@@ -68,6 +71,28 @@
   :let _p CapnProto.Pointer.Struct.Builder
   :new from_pointer(@_p)
 
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
+  :const capn_proto_data_word_count U16: 2
+  :fun a: @_p.u64(0x0)
+  :fun b: @_p.u64(0x8)
+  :fun ref "a="(new_value): @_p.set_u64(0x0, new_value, 0)
+  :fun ref "b="(new_value): @_p.set_u64(0x8, new_value, 0)
+
+  :const capn_proto_pointer_count U16: 2
+  :fun ref name: @_p.text(0)
+  :fun ref "name="(new_value): @_p.set_text(0, new_value, "")
+
+  :fun ref referenced: _ExampleReferencedBuilder.from_pointer(@_p.struct(1, 2, 1))
+  :fun ref referenced_if_set!: _ExampleReferencedBuilder.from_pointer(@_p.struct_if_set!(1, 2, 1))
+  :fun ref set_referenced_to_point_to_existing(existing _ExampleReferencedBuilder): _ExampleReferencedBuilder.from_pointer(@_p.set_struct_to_point_to_existing(1, existing._p))
+
+:struct _ExampleReferencedBuilder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
   :const capn_proto_data_word_count U16: 2
   :fun a: @_p.u64(0x0)
   :fun b: @_p.u64(0x8)
@@ -82,6 +107,8 @@
   :let _p CapnProto.Pointer.Struct.Builder
   :new from_pointer(@_p)
 
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
   :const capn_proto_data_word_count U16: 7
   :fun some_u64: @_p.u64(0x20)
   :fun some_u32: @_p.u32(0x28)
@@ -95,6 +122,8 @@
 :struct _ExampleAsBarBuilder
   :let _p CapnProto.Pointer.Struct.Builder
   :new from_pointer(@_p)
+
+  :fun capn_proto_address U64: @_p.capn_proto_address
 
   :const capn_proto_data_word_count U16: 7
   :fun some_f64: @_p.f64(0x20)
@@ -234,6 +263,68 @@
     assert: bar.some_f32 == 0, bar.some_f32 = 43.3, assert: bar.some_f32 == 43.3
     assert: "\(bar.blob)" == "", bar.blob = b"!!", assert: "\(bar.blob)" == "!!"
 
+  :it "lets you point two parents to the same child struct in memory"
+    message = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
+    root = message.root
+
+    assert: root.init_children(4).size == 4
+    assert: root.children.size == 4
+
+    assert error: root.children[0]!.referenced_if_set!
+    assert error: root.children[1]!.referenced_if_set!
+
+    assert no_error: (
+      root.children[0]!.referenced.a = 11
+      root.children[0]!.referenced.b = 22
+      root.children[0]!.referenced.name = "foo"
+    )
+
+    assert: root.children[1]!.set_referenced_to_point_to_existing(
+      root.children[0]!.referenced
+    ).capn_proto_address == root.children[0]!.referenced.capn_proto_address
+
+    assert: root.children[1]!.referenced.a == 11
+    assert: root.children[1]!.referenced.b == 22
+    assert: "\(root.children[1]!.referenced.name)" == "foo"
+
+    assert no_error: (
+      root.children[0]!.referenced.a = 33
+      root.children[0]!.referenced.b = 44
+      root.children[0]!.referenced.name = "bar"
+    )
+
+    assert: root.children[1]!.referenced.a == 33
+    assert: root.children[1]!.referenced.b == 44
+    assert: "\(root.children[1]!.referenced.name)" == "bar"
+
+    assert no_error: (
+      root.children[2]!.referenced.a = 55
+      root.children[2]!.referenced.b = 66
+      root.children[2]!.referenced.name = "baz"
+    )
+
+    assert: root.children[0]!.set_referenced_to_point_to_existing(
+      root.children[2]!.referenced
+    ).capn_proto_address == root.children[2]!.referenced.capn_proto_address
+
+    assert: root.children[0]!.referenced.a == 55
+    assert: root.children[0]!.referenced.b == 66
+    assert: "\(root.children[0]!.referenced.name)" == "baz"
+
+    assert: root.children[1]!.referenced.a == 33
+    assert: root.children[1]!.referenced.b == 44
+    assert: "\(root.children[1]!.referenced.name)" == "bar"
+
+    assert no_error: (
+      root.children[3]!.referenced.a = 77
+      root.children[3]!.referenced.b = 88
+      root.children[3]!.referenced.name = "qux"
+    )
+
+    assert: root.children[1]!.referenced.a == 33
+    assert: root.children[1]!.referenced.b == 44
+    assert: "\(root.children[1]!.referenced.name)" == "bar"
+
   :it "lets you take the resulting byte buffers"
     message = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
     buffers = message.take_val_buffers
@@ -244,7 +335,7 @@
 
     buffers = message.take_val_buffers
     assert: buffers.size == 1
-    assert: buffers[0]!.size == 0x5E18
+    assert: buffers[0]!.size == 0x7D50
     assert: buffers[0]!.space == 0x8000
 
     message.root // allocate just the root struct

--- a/src/CapnProto.Meta.capnp.savi
+++ b/src/CapnProto.Meta.capnp.savi
@@ -1285,9 +1285,11 @@
 
   :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(3, 3, 1))
   :fun ref type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(3, 3, 1))
+  :fun ref set_type_to_point_to_existing(existing CapnProto.Meta.Type.Builder): CapnProto.Meta.Type.Builder.from_pointer(@_p.set_struct_to_point_to_existing(3, existing._p))
 
   :fun ref value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(4, 2, 1))
   :fun ref value_if_set!: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct_if_set!(4, 2, 1))
+  :fun ref set_value_to_point_to_existing(existing CapnProto.Meta.Value.Builder): CapnProto.Meta.Value.Builder.from_pointer(@_p.set_struct_to_point_to_existing(4, existing._p))
 
 :struct CapnProto.Meta.Node.AS_annotation.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1304,6 +1306,7 @@
 
   :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(3, 3, 1))
   :fun ref type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(3, 3, 1))
+  :fun ref set_type_to_point_to_existing(existing CapnProto.Meta.Type.Builder): CapnProto.Meta.Type.Builder.from_pointer(@_p.set_struct_to_point_to_existing(3, existing._p))
 
   :fun targets_file: @_p.bool(0xe, 0b00000001)
   :fun targets_file_if_set!: @_p.bool_if_set!(0xe, 0b00000001)
@@ -1466,9 +1469,11 @@
 
   :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(2, 3, 1))
   :fun ref type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(2, 3, 1))
+  :fun ref set_type_to_point_to_existing(existing CapnProto.Meta.Type.Builder): CapnProto.Meta.Type.Builder.from_pointer(@_p.set_struct_to_point_to_existing(2, existing._p))
 
   :fun ref default_value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(3, 2, 1))
   :fun ref default_value_if_set!: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct_if_set!(3, 2, 1))
+  :fun ref set_default_value_to_point_to_existing(existing CapnProto.Meta.Value.Builder): CapnProto.Meta.Value.Builder.from_pointer(@_p.set_struct_to_point_to_existing(3, existing._p))
 
   :fun had_explicit_default: @_p.bool(0x10, 0b00000001)
   :fun had_explicit_default_if_set!: @_p.bool_if_set!(0x10, 0b00000001)
@@ -1566,6 +1571,7 @@
 
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
   :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(0, 0, 1))
+  :fun ref set_brand_to_point_to_existing(existing CapnProto.Meta.Brand.Builder): CapnProto.Meta.Brand.Builder.from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
 
 :struct CapnProto.Meta.Method.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1605,9 +1611,11 @@
 
   :fun ref param_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(2, 0, 1))
   :fun ref param_brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(2, 0, 1))
+  :fun ref set_param_brand_to_point_to_existing(existing CapnProto.Meta.Brand.Builder): CapnProto.Meta.Brand.Builder.from_pointer(@_p.set_struct_to_point_to_existing(2, existing._p))
 
   :fun ref result_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(3, 0, 1))
   :fun ref result_brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(3, 0, 1))
+  :fun ref set_result_brand_to_point_to_existing(existing CapnProto.Meta.Brand.Builder): CapnProto.Meta.Brand.Builder.from_pointer(@_p.set_struct_to_point_to_existing(3, existing._p))
 
   :fun ref implicit_parameters: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list(4))
   :fun ref implicit_parameters_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list_if_set!(4))
@@ -1784,6 +1792,7 @@
 
   :fun ref element_type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(0, 3, 1))
   :fun ref element_type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(0, 3, 1))
+  :fun ref set_element_type_to_point_to_existing(existing CapnProto.Meta.Type.Builder): CapnProto.Meta.Type.Builder.from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
 
 :struct CapnProto.Meta.Type.AS_enum.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1804,6 +1813,7 @@
 
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
   :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(0, 0, 1))
+  :fun ref set_brand_to_point_to_existing(existing CapnProto.Meta.Brand.Builder): CapnProto.Meta.Brand.Builder.from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
 
 :struct CapnProto.Meta.Type.AS_struct.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1824,6 +1834,7 @@
 
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
   :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(0, 0, 1))
+  :fun ref set_brand_to_point_to_existing(existing CapnProto.Meta.Brand.Builder): CapnProto.Meta.Brand.Builder.from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
 
 :struct CapnProto.Meta.Type.AS_interface.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1844,6 +1855,7 @@
 
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
   :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(0, 0, 1))
+  :fun ref set_brand_to_point_to_existing(existing CapnProto.Meta.Brand.Builder): CapnProto.Meta.Brand.Builder.from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
 
 :struct CapnProto.Meta.Type.AS_anyPointer.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -2219,9 +2231,11 @@
 
   :fun ref value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(0, 2, 1))
   :fun ref value_if_set!: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct_if_set!(0, 2, 1))
+  :fun ref set_value_to_point_to_existing(existing CapnProto.Meta.Value.Builder): CapnProto.Meta.Value.Builder.from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
 
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(1, 0, 1))
   :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(1, 0, 1))
+  :fun ref set_brand_to_point_to_existing(existing CapnProto.Meta.Brand.Builder): CapnProto.Meta.Brand.Builder.from_pointer(@_p.set_struct_to_point_to_existing(1, existing._p))
 
 :struct CapnProto.Meta.CodeGeneratorRequest.Builder
   :let _p CapnProto.Pointer.Struct.Builder

--- a/src/CapnProto.Pointer.Struct.savi
+++ b/src/CapnProto.Pointer.Struct.savi
@@ -469,6 +469,26 @@
 
     new_pointer
 
+  :fun ref set_struct_to_point_to_existing(
+    n U16
+    existing_pointer CapnProto.Pointer.Struct.Builder
+  ) CapnProto.Pointer.Struct.Builder
+    // We expect the byte offset to be within bounds - otherwise we can't do it,
+    // and we'll return an empty struct to signal this problem.
+    byte_offset = try (@_ptr_byte_offset!(n) | return @_empty_struct)
+
+    // If there's an existing struct pointer, we don't free it.
+    // Something else may be referring to it still.
+    // TODO: By this logic, should we perhaps never free anything?
+
+    // We need to write the pointer to the buffer so it can be followed.
+    try @_segment._set_u64!(
+      byte_offset
+      _WriteStructPointer._encode(byte_offset, existing_pointer)
+    )
+
+    existing_pointer
+
   :fun ref list(n): try (@list_if_set!(n) | @_empty_list)
   :fun ref _empty_list
     CapnProto.Pointer.StructList.Builder.empty(@_segment)

--- a/src/capnpc-savi/_Gen.savi
+++ b/src/capnpc-savi/_Gen.savi
@@ -317,14 +317,23 @@
     error! if is_union
 
     slot = field.slot!
-    // TODO: implement pointer setter as a deep copy, like C++ does
+    // TODO: Implement other pointer-sharing setter options
     error! if (
       slot.type.is_void ||
-      (@_is_pointer_type(slot.type) && !slot.type.is_text && !slot.type.is_data)
+      (
+        @_is_pointer_type(slot.type) &&
+        !slot.type.is_text && !slot.type.is_data && !slot.type.is_struct
+      )
     )
 
-    @_out << "\n  :fun ref \"\(_TextCase.Snake[field.name])=\"(new_value): "
-    @_emit_field_set_expr(field, "new_value")
+    if slot.type.is_struct (
+      @_out << "\n  :fun ref set_\(_TextCase.Snake[field.name]
+        )_to_point_to_existing(existing \(@_type_name(slot.type, True))): "
+      @_emit_field_set_to_point_to_existing_expr(field, "existing._p")
+    |
+      @_out << "\n  :fun ref \"\(_TextCase.Snake[field.name])=\"(new_value): "
+      @_emit_field_set_expr(field, "new_value")
+    )
 
   :fun ref _emit_field_list_initter!(
     node CapnProto.Meta.Node
@@ -616,6 +625,22 @@
       @_out << "None // UNHANDLED: interface" // TODO: handle interfaces
     | type.is_any_pointer |
       @_out << "None // UNHANDLED: anyPointer" // TODO: handle "any pointer"
+    |
+      @_out << "NOT_IMPLEMENTED"
+    )
+
+  :fun ref _emit_field_set_to_point_to_existing_expr(
+    field CapnProto.Meta.Field
+    input_name String
+  )
+    slot = try (field.slot! | return)
+
+    type = slot.type
+    offset = slot.offset
+    case (
+    | type.is_struct |
+      @_out << "\(@_type_name(type, True)).from_pointer(\(
+      )@_p.set_struct_to_point_to_existing(\(offset), \(input_name)))"
     |
       @_out << "NOT_IMPLEMENTED"
     )


### PR DESCRIPTION
This will allow for more conservative use of memory when building messages, such that many nodes on a message tree can point to a common node (e.g. many Source.Position structs pointing to the same Source struct).