### PR TITLE
Add missing `size` method to `CapnProto.Pointer.U8List`.

### DIFF
--- a/src/CapnProto.Pointer.U8List.savi
+++ b/src/CapnProto.Pointer.U8List.savi
@@ -134,8 +134,9 @@
     )
 
   :is Indexable(U8)
-
+  :fun size: @_byte_count.usize
   :fun "[]!"(index)
+    error! if index >= @size
     @_segment._bytes[@_byte_offset.usize +! index]!
 
   :fun each_with_index(from USize = 0, to = USize.max_value, stride USize = 1)


### PR DESCRIPTION
This is now required by the `Indexable` trait.