### PR TITLE
Add `val` pattern support for `CapnProto.Message`.

### DIFF
--- a/spec/CapnProto.Message.Builder.Spec.savi
+++ b/spec/CapnProto.Message.Builder.Spec.savi
@@ -1,5 +1,12 @@
 // TODO: Generate the following test structs via capnpc-savi
 
+:struct box _ExamplePartialReader
+  :let _p CapnProto.Pointer.Struct
+  :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
+
+  :fun some_text: @_p.text(0)
+
 :struct _ExampleBuilder
   :let _p CapnProto.Pointer.Struct.Builder
   :new from_pointer(@_p)
@@ -344,3 +351,26 @@
     assert: buffers.size == 1
     assert: buffers[0]!.size == 0x68
     assert: buffers[0]!.space == 0x4000
+
+  :it "lets you take the resulting message as a val"
+    builder = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
+    builder.root.some_text = "foo"
+
+    assert no_error: (
+      message val = CapnProto.Message(_ExamplePartialReader).from_val_segments!(
+        builder.take_val_segments
+      )
+
+      assert: "\(message.root.some_text)" == "foo"
+
+      assert: message.val_buffers.size == 1
+      assert: message.val_buffers[0]! == b"\
+        \x00\x00\x00\x00\x07\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+        \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+        \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+        \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+        \x11\x00\x00\x00\"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+        \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+        \x00\x00\x00\x00\x00\x00\x00\x00foo\x00\x00\x00\x00\x00\
+      "
+    )

--- a/src/CapnProto.Data.savi
+++ b/src/CapnProto.Data.savi
@@ -2,6 +2,7 @@
   :let _p CapnProto.Pointer.U8List'box
   :new from_pointer(@_p)
   :new box read_from_pointer(p CapnProto.Pointer.U8List'box): @_p = p
+  :new val read_val_from_pointer(p CapnProto.Pointer.U8List'val): @_p = p
 
   :new _new(segment CapnProto.Segment, value Bytes)
     byte_offset = segment._allocate_and_write_bytes(value)

--- a/src/CapnProto.List.savi
+++ b/src/CapnProto.List.savi
@@ -1,10 +1,12 @@
 :trait box _FromStructPointer
   :is TraceData
   :new box read_from_pointer(pointer CapnProto.Pointer.Struct)
+  :new val read_val_from_pointer(pointer CapnProto.Pointer.Struct'val)
 
 :struct box CapnProto.List(A _FromStructPointer)
   :let _p CapnProto.Pointer.StructList
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.StructList'val): @_p = p
 
   :fun size: @_p._list_count.usize
 

--- a/src/CapnProto.Message.savi
+++ b/src/CapnProto.Message.savi
@@ -1,19 +1,36 @@
 :trait box _MessageRoot
   :new box read_from_pointer(p CapnProto.Pointer.Struct)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val)
 
 :struct box CapnProto.Message(A _MessageRoot)
-  :let root A
-  :new box (@root)
+  :let _p CapnProto.Pointer.Struct
+
+  :new box (@_p)
+  :new val new_val(p CapnProto.Pointer.Struct'val): @_p = p
+
+  :fun root: A.read_from_pointer(@_p)
+  :fun val val_root: A.read_val_from_pointer(@_p)
+
+  :fun val val_buffers
+    @_p._segment._segments.val_buffers
 
   :fun non from_segments!(
-    segments CapnProto.Segments
+    segments CapnProto.Segments'box
     start_offset USize = 0
     segment_index USize = 0
   )
     segment = segments._list[segment_index]!
     value = segment._u64!(start_offset.u32)
-    pointer = _ParseStructPointer._parse!(segment, start_offset.u32, value)
-    @new(A.read_from_pointer(pointer))
+    @new(_ParseStructPointer._parse!(segment, start_offset.u32, value))
+
+  :fun non from_val_segments!(
+    segments CapnProto.Segments'val
+    start_offset USize = 0
+    segment_index USize = 0
+  )
+    segment = segments._list[segment_index]!
+    value = segment._u64!(start_offset.u32)
+    @new_val(_ParseStructPointer._parse_val!(segment, start_offset.u32, value))
 
 :trait _MessageBuilderRoot
   :new from_pointer(p CapnProto.Pointer.Struct.Builder)
@@ -34,6 +51,7 @@
     @_segments = CapnProto.Segments.new
 
   :fun ref take_val_buffers: @_segments.take_val_buffers
+  :fun ref take_val_segments: @_segments.take_val_segments
 
   :fun ref root
     segment = try (

--- a/src/CapnProto.Meta.capnp.savi
+++ b/src/CapnProto.Meta.capnp.savi
@@ -5,6 +5,7 @@
 :struct box CapnProto.Meta.Node
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
@@ -80,6 +81,7 @@
 :struct box CapnProto.Meta.Node.AS_struct
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
@@ -121,6 +123,7 @@
 :struct box CapnProto.Meta.Node.AS_enum
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
@@ -138,6 +141,7 @@
 :struct box CapnProto.Meta.Node.AS_interface
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
@@ -159,6 +163,7 @@
 :struct box CapnProto.Meta.Node.AS_const
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
@@ -180,6 +185,7 @@
 :struct box CapnProto.Meta.Node.AS_annotation
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
@@ -245,6 +251,7 @@
 :struct box CapnProto.Meta.Node.Parameter
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 1
@@ -262,6 +269,7 @@
 :struct box CapnProto.Meta.Node.NestedNode
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
@@ -283,6 +291,7 @@
 :struct box CapnProto.Meta.Field
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
@@ -328,6 +337,7 @@
 :struct box CapnProto.Meta.Field.AS_slot
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
@@ -357,6 +367,7 @@
 :struct box CapnProto.Meta.Field.AS_group
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
@@ -374,6 +385,7 @@
 :struct box CapnProto.Meta.Field.AS_ordinal
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
@@ -397,6 +409,7 @@
 :struct box CapnProto.Meta.Enumerant
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
@@ -422,6 +435,7 @@
 :struct box CapnProto.Meta.Superclass
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
@@ -443,6 +457,7 @@
 :struct box CapnProto.Meta.Method
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 5
@@ -488,6 +503,7 @@
 :struct box CapnProto.Meta.Type
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
@@ -596,6 +612,7 @@
 :struct box CapnProto.Meta.Type.AS_list
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
@@ -613,6 +630,7 @@
 :struct box CapnProto.Meta.Type.AS_enum
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
@@ -634,6 +652,7 @@
 :struct box CapnProto.Meta.Type.AS_struct
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
@@ -655,6 +674,7 @@
 :struct box CapnProto.Meta.Type.AS_interface
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
@@ -676,6 +696,7 @@
 :struct box CapnProto.Meta.Type.AS_anyPointer
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
@@ -704,6 +725,7 @@
 :struct box CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
@@ -737,6 +759,7 @@
 :struct box CapnProto.Meta.Type.AS_anyPointer.AS_parameter
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
@@ -758,6 +781,7 @@
 :struct box CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
@@ -775,6 +799,7 @@
 :struct box CapnProto.Meta.Brand
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 1
@@ -792,6 +817,7 @@
 :struct box CapnProto.Meta.Brand.Scope
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 2
   :const capn_proto_pointer_count U16: 1
@@ -819,6 +845,7 @@
 :struct box CapnProto.Meta.Brand.Binding
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
@@ -842,6 +869,7 @@
 :struct box CapnProto.Meta.Value
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 2
   :const capn_proto_pointer_count U16: 1
@@ -950,6 +978,7 @@
 :struct box CapnProto.Meta.Annotation
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
@@ -994,6 +1023,7 @@
 :struct box CapnProto.Meta.CodeGeneratorRequest
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 2
@@ -1015,6 +1045,7 @@
 :struct box CapnProto.Meta.CodeGeneratorRequest.RequestedFile
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
@@ -1040,6 +1071,7 @@
 :struct box CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import
   :let _p CapnProto.Pointer.Struct
   :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
 
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1

--- a/src/CapnProto.Pointer.Struct.savi
+++ b/src/CapnProto.Pointer.Struct.savi
@@ -56,6 +56,16 @@
       segment, byte_offset, data_word_count, pointer_count
     )
 
+  :fun _parse_val!(segment CapnProto.Segment'val, current_offset U32, value U64)
+    box_ptr = @_parse!(segment, current_offset, value)
+    if box_ptr._segment !== segment (
+      try (segment = segment._segments._list[box_ptr._segment.index]!)
+    )
+    CapnProto.Pointer.Struct._new_val(
+      segment, box_ptr._byte_offset
+      box_ptr._data_word_count, box_ptr._pointer_count
+    )
+
   :fun _parse_builder!(segment CapnProto.Segment, current_offset, value)
     read_ptr = @_parse!(segment, current_offset, value)
     if read_ptr._segment !== segment (
@@ -100,6 +110,12 @@
     @_segment, @_byte_offset
     @_data_word_count, @_pointer_count
   )
+
+  :new val _new_val(
+    segment CapnProto.Segment'val, @_byte_offset
+    @_data_word_count, @_pointer_count
+  )
+    @_segment = segment
 
   :new box empty(@_segment)
     @_byte_offset = 0

--- a/src/CapnProto.Segments.savi
+++ b/src/CapnProto.Segments.savi
@@ -2,11 +2,30 @@
   :let _list Array(CapnProto.Segment)'ref
   :new: @_list = []
 
+  :fun val val_buffers Array(Bytes)'val
+    out Array(Bytes)'iso = []
+    @_list.each -> (segment | out << segment._bytes)
+    --out
+
   :fun ref take_val_buffers Array(Bytes)'val
     out Array(Bytes)'iso = []
     @_list.each -> (segment | out << segment._take_buffer)
     @_list.clear
     --out
+
+  :fun ref _take_iso_ref_buffers Array(Bytes'ref)'iso
+    out Array(Bytes'ref)'iso = []
+    @_list.each -> (segment | out << segment._take_buffer)
+    @_list.clear
+    --out
+
+  :fun ref take_val_segments @'val
+    @_val_from_buffers(@_take_iso_ref_buffers)
+
+  :new val _val_from_buffers(buffers_iso Array(Bytes'ref)'iso)
+    buffers ref = --buffers_iso
+    @_list = []
+    buffers.each -> (buffer | CapnProto.Segment.new_from_bytes(@, buffer))
 
 :class CapnProto.Segments.Reader
   :var _header: b""

--- a/src/capnpc-savi/_Gen.savi
+++ b/src/capnpc-savi/_Gen.savi
@@ -187,6 +187,9 @@
       @_out << "\n  :fun as_reader: \(
         node_scoped_name
       ).read_from_pointer(@_p.as_reader)"
+    |
+      @_out << "\n  :new val read_val_from_pointer"
+      @_out << "(p CapnProto.Pointer.Struct'val): @_p = p"
     )
 
     // Emit protocol-level constant info.


### PR DESCRIPTION
This allows immutable messages to be passed between actors (for example, via a router actor to a socket actor to send).