### PR TITLE
Generate `copy_data_from` methods for all struct builders.

### DIFF
--- a/.github/workflows/library-check.yaml
+++ b/.github/workflows/library-check.yaml
@@ -63,4 +63,5 @@ jobs:
       - run: savi deps update --for capnpc-savi
       - run: savi build capnpc-savi
       - run: capnp compile src/CapnProto.Meta.capnp --output=- | bin/capnpc-savi > src/CapnProto.Meta.capnp.savi
+      - run: capnp compile -Isrc/ spec/_Example.capnp --output=- | bin/capnpc-savi > spec/_Example.capnp.savi
       - run: git diff --exit-code

--- a/spec/CapnProto.Message.Builder.Spec.savi
+++ b/spec/CapnProto.Message.Builder.Spec.savi
@@ -1,153 +1,9 @@
-// TODO: Generate the following test structs via capnpc-savi
-
-:struct box _ExamplePartialReader
-  :let _p CapnProto.Pointer.Struct
-  :new box read_from_pointer(@_p)
-  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
-
-  :fun some_text: @_p.text(0)
-
-:struct _ExampleBuilder
-  :let _p CapnProto.Pointer.Struct.Builder
-  :new from_pointer(@_p)
-
-  :fun capn_proto_address U64: @_p.capn_proto_address
-
-  :const capn_proto_data_word_count U16: 7
-  :fun some_u64: @_p.u64(0x0)
-  :fun some_i64: @_p.i64(0x8)
-  :fun some_u32: @_p.u32(0x10)
-  :fun some_i32: @_p.i32(0x14)
-  :fun some_u16: @_p.u16(0x18)
-  :fun some_i16: @_p.i16(0x1c)
-  :fun some_u8: @_p.u8(0x1e)
-  :fun some_i8: @_p.i8(0x1f)
-  :fun some_u64_if_set!: @_p.u64_if_set!(0x0)
-  :fun some_i64_if_set!: @_p.i64_if_set!(0x8)
-  :fun some_u32_if_set!: @_p.u32_if_set!(0x10)
-  :fun some_i32_if_set!: @_p.i32_if_set!(0x14)
-  :fun some_u16_if_set!: @_p.u16_if_set!(0x18)
-  :fun some_i16_if_set!: @_p.i16_if_set!(0x1c)
-  :fun some_u8_if_set!: @_p.u8_if_set!(0x1e)
-  :fun some_i8_if_set!: @_p.i8_if_set!(0x1f)
-  :fun ref "some_u64="(new_value): @_p.set_u64(0x0, new_value, 0)
-  :fun ref "some_i64="(new_value): @_p.set_i64(0x8, new_value, 0)
-  :fun ref "some_u32="(new_value): @_p.set_u32(0x10, new_value, 0)
-  :fun ref "some_i32="(new_value): @_p.set_i32(0x14, new_value, 0)
-  :fun ref "some_u16="(new_value): @_p.set_u16(0x18, new_value, 0)
-  :fun ref "some_i16="(new_value): @_p.set_i16(0x1c, new_value, 0)
-  :fun ref "some_u8="(new_value): @_p.set_u8(0x1e, new_value, 0)
-  :fun ref "some_i8="(new_value): @_p.set_i8(0x1f, new_value, 0)
-
-  :const capn_proto_pointer_count U16: 5
-  :fun ref some_text: @_p.text(0)
-  :fun ref some_data: @_p.data(1)
-  :fun ref some_text_if_set!: @_p.text_if_set!(0)
-  :fun ref some_data_if_set!: @_p.data_if_set!(1)
-  :fun ref "some_text="(new_value): @_p.set_text(0, new_value, "")
-  :fun ref "some_data="(new_value): @_p.set_data(1, new_value, b"")
-
-  :fun ref child: _ExampleChildBuilder.from_pointer(@_p.struct(2, 2, 2))
-  :fun ref child_if_set!: _ExampleChildBuilder.from_pointer(@_p.struct_if_set!(2, 2, 2))
-  :fun ref set_child_to_point_to_existing(existing _ExampleChildBuilder): _ExampleChildBuilder.from_pointer(@_p.set_struct_to_point_to_existing(2, existing._p))
-
-  :fun ref children: CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.list(3))
-  :fun ref children_if_set!: CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.list_if_set!(3))
-  :fun ref init_children(new_count): CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.init_list(3, 2, 2, new_count))
-  :fun ref trim_children(new_start, new_finish): CapnProto.List.Builder(_ExampleChildBuilder).from_pointer(@_p.trim_list(3, 2, 2, new_start, new_finish))
-
-  :fun is_foo: @_p.check_union(0x30, 0)
-  :fun ref foo!: @_p.assert_union!(0x30, 0), _ExampleAsFooBuilder.from_pointer(@_p)
-  :fun ref init_foo
-    @_p.clear_64(0x20)
-    @_p.clear_32(0x28)
-    @_p.clear_pointer(4)
-    @_p.mark_union(0x30, 0)
-    _ExampleAsFooBuilder.from_pointer(@_p)
-
-  :fun is_bar: @_p.check_union(0x30, 1)
-  :fun ref bar!: @_p.assert_union!(0x30, 1), _ExampleAsBarBuilder.from_pointer(@_p)
-  :fun ref init_bar
-    @_p.clear_64(0x20)
-    @_p.clear_32(0x28)
-    @_p.clear_pointer(4)
-    @_p.mark_union(0x30, 1)
-    _ExampleAsBarBuilder.from_pointer(@_p)
-
-:struct _ExampleChildBuilder
-  :let _p CapnProto.Pointer.Struct.Builder
-  :new from_pointer(@_p)
-
-  :fun capn_proto_address U64: @_p.capn_proto_address
-
-  :const capn_proto_data_word_count U16: 2
-  :fun a: @_p.u64(0x0)
-  :fun b: @_p.u64(0x8)
-  :fun ref "a="(new_value): @_p.set_u64(0x0, new_value, 0)
-  :fun ref "b="(new_value): @_p.set_u64(0x8, new_value, 0)
-
-  :const capn_proto_pointer_count U16: 2
-  :fun ref name: @_p.text(0)
-  :fun ref "name="(new_value): @_p.set_text(0, new_value, "")
-
-  :fun ref referenced: _ExampleReferencedBuilder.from_pointer(@_p.struct(1, 2, 1))
-  :fun ref referenced_if_set!: _ExampleReferencedBuilder.from_pointer(@_p.struct_if_set!(1, 2, 1))
-  :fun ref set_referenced_to_point_to_existing(existing _ExampleReferencedBuilder): _ExampleReferencedBuilder.from_pointer(@_p.set_struct_to_point_to_existing(1, existing._p))
-
-:struct _ExampleReferencedBuilder
-  :let _p CapnProto.Pointer.Struct.Builder
-  :new from_pointer(@_p)
-
-  :fun capn_proto_address U64: @_p.capn_proto_address
-
-  :const capn_proto_data_word_count U16: 2
-  :fun a: @_p.u64(0x0)
-  :fun b: @_p.u64(0x8)
-  :fun ref "a="(new_value): @_p.set_u64(0x0, new_value, 0)
-  :fun ref "b="(new_value): @_p.set_u64(0x8, new_value, 0)
-
-  :const capn_proto_pointer_count U16: 1
-  :fun ref name: @_p.text(0)
-  :fun ref "name="(new_value): @_p.set_text(0, new_value, "")
-
-:struct _ExampleAsFooBuilder
-  :let _p CapnProto.Pointer.Struct.Builder
-  :new from_pointer(@_p)
-
-  :fun capn_proto_address U64: @_p.capn_proto_address
-
-  :const capn_proto_data_word_count U16: 7
-  :fun some_u64: @_p.u64(0x20)
-  :fun some_u32: @_p.u32(0x28)
-  :fun ref "some_u64="(new_value): @_p.set_u64(0x20, new_value, 0)
-  :fun ref "some_u32="(new_value): @_p.set_u32(0x28, new_value, 0)
-
-  :const capn_proto_pointer_count U16: 5
-  :fun ref txt: @_p.text(4)
-  :fun ref "txt="(new_value): @_p.set_text(4, new_value, "")
-
-:struct _ExampleAsBarBuilder
-  :let _p CapnProto.Pointer.Struct.Builder
-  :new from_pointer(@_p)
-
-  :fun capn_proto_address U64: @_p.capn_proto_address
-
-  :const capn_proto_data_word_count U16: 7
-  :fun some_f64: @_p.f64(0x20)
-  :fun some_f32: @_p.f32(0x28)
-  :fun ref "some_f64="(new_value): @_p.set_f64(0x20, new_value, 0)
-  :fun ref "some_f32="(new_value): @_p.set_f32(0x28, new_value, 0)
-
-  :const capn_proto_pointer_count U16: 5
-  :fun ref blob: @_p.data(4)
-  :fun ref "blob="(new_value): @_p.set_data(4, new_value, b"")
-
 :class CapnProto.Message.Builder.Spec
   :is Spec
   :const describes: "CapnProto.Message.Builder"
 
   :it "reads from and writes to fields of the root struct"
-    message = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
+    message = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
     root = message.root
     assert: root.some_u64 == 0, root.some_u64 = 35, assert: root.some_u64 == 35
     assert: root.some_i64 == 0, root.some_i64 = 36, assert: root.some_i64 == 36
@@ -182,8 +38,29 @@
     assert: "\(root.some_data)"         == ""
     assert error: root.some_data_if_set!
 
+    message2 = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
+    root2 = message2.root
+    root2.copy_data_from(root.as_reader)
+
+    assert: root2.some_u64 == 35
+    assert: root2.some_i64 == 36
+    assert: root2.some_u32 == 37
+    assert: root2.some_i32 == 38
+    assert: root2.some_u16 == 39
+    assert: root2.some_i16 == 40
+    assert: root2.some_u8  == 41
+    assert: root2.some_i8  == 42
+    assert: "\(root2.some_text)" == ""
+    assert: "\(root2.some_data)" == ""
+
+    root.some_text = "foo"
+    root.some_data = b"bar"
+    root2.copy_data_from(root.as_reader)
+    assert: "\(root2.some_text)" == "foo"
+    assert: "\(root2.some_data)" == "bar"
+
   :it "reads from and writes to fields of the child struct"
-    message = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
+    message = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
     root = message.root
     assert error: root.child_if_set!
     assert: root.child.a == 0, root.child.a = 77, assert: root.child.a == 77
@@ -194,8 +71,16 @@
     assert: "\(root.child.name)" == "Alice"
     assert: "\(root.child_if_set!.name)" == "Alice"
 
+    message2 = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
+    root2 = message2.root
+    root2.copy_data_from(root.as_reader)
+
+    assert: root2.child.a == 77
+    assert: root2.child.b == 88
+    assert: "\(root2.child.name)" == "Alice"
+
   :it "reads from and writes to fields of the list children structs"
-    message = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
+    message = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
     root = message.root
 
     assert: root.children.size == 0
@@ -223,6 +108,21 @@
     assert: (children[2]!.b = 66, children[2]!.b == 66)
     assert: (children[2]!.name = "baz", "\(children[2]!.name)" == "baz")
 
+    message2 = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
+    root2 = message2.root
+    root2.copy_data_from(root.as_reader)
+
+    assert: root2.children.size == 3
+    assert: root2.children[0]!.a == 11
+    assert: root2.children[0]!.b == 22
+    assert: "\(root2.children[0]!.name)" == "foo"
+    assert: root2.children[1]!.a == 33
+    assert: root2.children[1]!.b == 44
+    assert: "\(root2.children[1]!.name)" == "bar"
+    assert: root2.children[2]!.a == 55
+    assert: root2.children[2]!.b == 66
+    assert: "\(root2.children[2]!.name)" == "baz"
+
     children = root.trim_children(0, 3)
     assert: children.size == 3
     children = root.trim_children(0, 999)
@@ -247,7 +147,7 @@
     assert error: root.children[1000]!
 
   :it "marks union group membership and reads from and writes to union fields"
-    message = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
+    message = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
     root = message.root
 
     foo = root.init_foo
@@ -270,8 +170,19 @@
     assert: bar.some_f32 == 0, bar.some_f32 = 43.3, assert: bar.some_f32 == 43.3
     assert: "\(bar.blob)" == "", bar.blob = b"!!", assert: "\(bar.blob)" == "!!"
 
+    message2 = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
+    root2 = message2.root
+    root2.copy_data_from(root.as_reader)
+
+    assert: root2.is_foo.is_false
+    assert: root2.is_bar.is_true
+
+    assert: root2.bar!.some_f64 == 42.2
+    assert: root2.bar!.some_f32 == 43.3
+    assert: "\(root2.bar!.blob)" == "!!"
+
   :it "lets you point two parents to the same child struct in memory"
-    message = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
+    message = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
     root = message.root
 
     assert: root.init_children(4).size == 4
@@ -333,7 +244,7 @@
     assert: "\(root.children[1]!.referenced.name)" == "bar"
 
   :it "lets you take the resulting byte buffers"
-    message = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
+    message = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
     buffers = message.take_val_buffers
 
     assert: buffers.size == 0
@@ -342,22 +253,22 @@
 
     buffers = message.take_val_buffers
     assert: buffers.size == 1
-    assert: buffers[0]!.size == 0x7D50
+    assert: buffers[0]!.size == 0x7D48
     assert: buffers[0]!.space == 0x8000
 
     message.root // allocate just the root struct
 
     buffers = message.take_val_buffers
     assert: buffers.size == 1
-    assert: buffers[0]!.size == 0x68
+    assert: buffers[0]!.size == 0x60
     assert: buffers[0]!.space == 0x4000
 
   :it "lets you take the resulting message as a val"
-    builder = CapnProto.Message.Builder(_ExampleBuilder).new(0x4000)
+    builder = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
     builder.root.some_text = "foo"
 
     assert no_error: (
-      message val = CapnProto.Message(_ExamplePartialReader).from_val_segments!(
+      message val = CapnProto.Message(_Example.Root).from_val_segments!(
         builder.take_val_segments
       )
 
@@ -365,12 +276,12 @@
 
       assert: message.val_buffers.size == 1
       assert: message.val_buffers[0]! == b"\
-        \x00\x00\x00\x00\x07\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+        \x00\x00\x00\x00\x06\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\
         \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
         \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+        \x00\x00\x00\x00\x00\x00\x00\x00\x11\x00\x00\x00\"\x00\x00\x00\
         \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
-        \x11\x00\x00\x00\"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
         \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
-        \x00\x00\x00\x00\x00\x00\x00\x00foo\x00\x00\x00\x00\x00\
+        foo\x00\x00\x00\x00\x00\
       "
     )

--- a/spec/_Example.capnp
+++ b/spec/_Example.capnp
@@ -1,0 +1,44 @@
+@0xf22ee88b3fe8a474;
+
+using Savi = import "/CapnProto.Savi.Meta.capnp";
+$Savi.namespace("_Example");
+
+struct Root {
+  someU64 @0 :UInt64;
+  someI64 @1 :Int64;
+  someU32 @2 :UInt32;
+  someI32 @3 :Int32;
+  someU16 @4 :UInt16;
+  someI16 @5 :Int16;
+  someU8 @6 :UInt8;
+  someI8 @7 :Int8;
+
+  someText @8 :Text;
+  someData @9 :Data;
+
+  child @10 :Child;
+  children @11 :List(Child);
+
+  union {
+    foo :group {
+      someU64 @12 :UInt64;
+      someU32 @13 :UInt32;
+      txt @14 :Text;
+    }
+
+    bar :group {
+      someF64 @15 :Float64;
+      someF32 @16 :Float32;
+      blob @17 :Data;
+    }
+  }
+}
+
+struct Child {
+  a @0 :UInt64;
+  b @1 :UInt64;
+
+  name @2 :Text;
+
+  referenced @3 :Child;
+}

--- a/spec/_Example.capnp.savi
+++ b/spec/_Example.capnp.savi
@@ -1,0 +1,359 @@
+///
+// NOTE: This file was auto-generated from a Cap'n Proto file
+// using the `capnp` compiler with the `--output=savi` option.
+
+:struct box _Example.Root
+  :let _p CapnProto.Pointer.Struct
+  :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
+
+  :const capn_proto_data_word_count U16: 6
+  :const capn_proto_pointer_count U16: 5
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
+  :is TraceData
+  :fun trace_data(trace TraceData.Observer)
+    trace.object(@_p.absolute_address) -> (
+      try trace.property("some_u64", @some_u64_if_set!)
+      try trace.property("some_i64", @some_i64_if_set!)
+      try trace.property("some_u32", @some_u32_if_set!)
+      try trace.property("some_i32", @some_i32_if_set!)
+      try trace.property("some_u16", @some_u16_if_set!)
+      try trace.property("some_i16", @some_i16_if_set!)
+      try trace.property("some_u8", @some_u8_if_set!)
+      try trace.property("some_i8", @some_i8_if_set!)
+      try trace.property("some_text", @some_text_if_set!)
+      try trace.property("some_data", @some_data_if_set!)
+      try trace.property("child", @child_if_set!)
+      try trace.property("children", @children_if_set!)
+      try trace.property("foo", @foo!)
+      try trace.property("bar", @bar!)
+    )
+
+  :fun some_u64: @_p.u64(0x0)
+  :fun some_u64_if_set!: @_p.u64_if_set!(0x0)
+
+  :fun some_i64: @_p.i64(0x8)
+  :fun some_i64_if_set!: @_p.i64_if_set!(0x8)
+
+  :fun some_u32: @_p.u32(0x10)
+  :fun some_u32_if_set!: @_p.u32_if_set!(0x10)
+
+  :fun some_i32: @_p.i32(0x14)
+  :fun some_i32_if_set!: @_p.i32_if_set!(0x14)
+
+  :fun some_u16: @_p.u16(0x18)
+  :fun some_u16_if_set!: @_p.u16_if_set!(0x18)
+
+  :fun some_i16: @_p.i16(0x1a)
+  :fun some_i16_if_set!: @_p.i16_if_set!(0x1a)
+
+  :fun some_u8: @_p.u8(0x1c)
+  :fun some_u8_if_set!: @_p.u8_if_set!(0x1c)
+
+  :fun some_i8: @_p.i8(0x1d)
+  :fun some_i8_if_set!: @_p.i8_if_set!(0x1d)
+
+  :fun some_text: @_p.text(0)
+  :fun some_text_if_set!: @_p.text_if_set!(0)
+
+  :fun some_data: @_p.data(1)
+  :fun some_data_if_set!: @_p.data_if_set!(1)
+
+  :fun child: _Example.Child.read_from_pointer(@_p.struct(2))
+  :fun child_if_set!: _Example.Child.read_from_pointer(@_p.struct_if_set!(2))
+
+  :fun children: CapnProto.List(_Example.Child).read_from_pointer(@_p.list(3))
+  :fun children_if_set!: CapnProto.List(_Example.Child).read_from_pointer(@_p.list_if_set!(3))
+
+  :fun is_foo: @_p.check_union(0x1e, 0)
+  :fun foo!: @_p.assert_union!(0x1e, 0), _Example.Root.AS_foo.read_from_pointer(@_p)
+  :fun foo_if_set!: @_p.assert_union!(0x1e, 0), _Example.Root.AS_foo.read_from_pointer(@_p)
+
+  :fun is_bar: @_p.check_union(0x1e, 1)
+  :fun bar!: @_p.assert_union!(0x1e, 1), _Example.Root.AS_bar.read_from_pointer(@_p)
+  :fun bar_if_set!: @_p.assert_union!(0x1e, 1), _Example.Root.AS_bar.read_from_pointer(@_p)
+
+:struct box _Example.Root.AS_foo
+  :let _p CapnProto.Pointer.Struct
+  :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
+
+  :const capn_proto_data_word_count U16: 6
+  :const capn_proto_pointer_count U16: 5
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
+  :is TraceData
+  :fun trace_data(trace TraceData.Observer)
+    trace.object(0) -> (
+      try trace.property("some_u64", @some_u64_if_set!)
+      try trace.property("some_u32", @some_u32_if_set!)
+      try trace.property("txt", @txt_if_set!)
+    )
+
+  :fun some_u64: @_p.u64(0x20)
+  :fun some_u64_if_set!: @_p.u64_if_set!(0x20)
+
+  :fun some_u32: @_p.u32(0x28)
+  :fun some_u32_if_set!: @_p.u32_if_set!(0x28)
+
+  :fun txt: @_p.text(4)
+  :fun txt_if_set!: @_p.text_if_set!(4)
+
+:struct box _Example.Root.AS_bar
+  :let _p CapnProto.Pointer.Struct
+  :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
+
+  :const capn_proto_data_word_count U16: 6
+  :const capn_proto_pointer_count U16: 5
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
+  :is TraceData
+  :fun trace_data(trace TraceData.Observer)
+    trace.object(0) -> (
+      try trace.property("some_f64", @some_f64_if_set!)
+      try trace.property("some_f32", @some_f32_if_set!)
+      try trace.property("blob", @blob_if_set!)
+    )
+
+  :fun some_f64: @_p.f64(0x20)
+  :fun some_f64_if_set!: @_p.f64_if_set!(0x20)
+
+  :fun some_f32: @_p.f32(0x28)
+  :fun some_f32_if_set!: @_p.f32_if_set!(0x28)
+
+  :fun blob: @_p.data(4)
+  :fun blob_if_set!: @_p.data_if_set!(4)
+
+:struct box _Example.Child
+  :let _p CapnProto.Pointer.Struct
+  :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
+
+  :const capn_proto_data_word_count U16: 2
+  :const capn_proto_pointer_count U16: 2
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
+  :is TraceData
+  :fun trace_data(trace TraceData.Observer)
+    trace.object(@_p.absolute_address) -> (
+      try trace.property("a", @a_if_set!)
+      try trace.property("b", @b_if_set!)
+      try trace.property("name", @name_if_set!)
+      try trace.property("referenced", @referenced_if_set!)
+    )
+
+  :fun a: @_p.u64(0x0)
+  :fun a_if_set!: @_p.u64_if_set!(0x0)
+
+  :fun b: @_p.u64(0x8)
+  :fun b_if_set!: @_p.u64_if_set!(0x8)
+
+  :fun name: @_p.text(0)
+  :fun name_if_set!: @_p.text_if_set!(0)
+
+  :fun referenced: _Example.Child.read_from_pointer(@_p.struct(1))
+  :fun referenced_if_set!: _Example.Child.read_from_pointer(@_p.struct_if_set!(1))
+
+:struct _Example.Root.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+  :fun as_reader: _Example.Root.read_from_pointer(@_p.as_reader)
+
+  :const capn_proto_data_word_count U16: 6
+  :const capn_proto_pointer_count U16: 5
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
+  :is TraceData
+  :fun trace_data(trace TraceData.Observer)
+    @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other _Example.Root) None
+    try @_p.set_u64(0x0, other.some_u64_if_set!, 0)
+    try @_p.set_i64(0x8, other.some_i64_if_set!, 0)
+    try @_p.set_u32(0x10, other.some_u32_if_set!, 0)
+    try @_p.set_i32(0x14, other.some_i32_if_set!, 0)
+    try @_p.set_u16(0x18, other.some_u16_if_set!, 0)
+    try @_p.set_i16(0x1a, other.some_i16_if_set!, 0)
+    try @_p.set_u8(0x1c, other.some_u8_if_set!, 0)
+    try @_p.set_i8(0x1d, other.some_i8_if_set!, 0)
+    try @_p.set_text(0, "\(other.some_text_if_set!)", "")
+    try @_p.set_data(1, "\(other.some_data_if_set!)".as_bytes, b"")
+    try (other_child = other.child_if_set!, @child.copy_data_from(other_child))
+    try @init_children_and_copy_data_from(other.children_if_set!)
+    try (other_foo = other.foo!, @init_foo.copy_data_from(other_foo))
+    try (other_bar = other.bar!, @init_bar.copy_data_from(other_bar))
+
+  :fun some_u64: @_p.u64(0x0)
+  :fun some_u64_if_set!: @_p.u64_if_set!(0x0)
+  :fun ref "some_u64="(new_value): @_p.set_u64(0x0, new_value, 0)
+
+  :fun some_i64: @_p.i64(0x8)
+  :fun some_i64_if_set!: @_p.i64_if_set!(0x8)
+  :fun ref "some_i64="(new_value): @_p.set_i64(0x8, new_value, 0)
+
+  :fun some_u32: @_p.u32(0x10)
+  :fun some_u32_if_set!: @_p.u32_if_set!(0x10)
+  :fun ref "some_u32="(new_value): @_p.set_u32(0x10, new_value, 0)
+
+  :fun some_i32: @_p.i32(0x14)
+  :fun some_i32_if_set!: @_p.i32_if_set!(0x14)
+  :fun ref "some_i32="(new_value): @_p.set_i32(0x14, new_value, 0)
+
+  :fun some_u16: @_p.u16(0x18)
+  :fun some_u16_if_set!: @_p.u16_if_set!(0x18)
+  :fun ref "some_u16="(new_value): @_p.set_u16(0x18, new_value, 0)
+
+  :fun some_i16: @_p.i16(0x1a)
+  :fun some_i16_if_set!: @_p.i16_if_set!(0x1a)
+  :fun ref "some_i16="(new_value): @_p.set_i16(0x1a, new_value, 0)
+
+  :fun some_u8: @_p.u8(0x1c)
+  :fun some_u8_if_set!: @_p.u8_if_set!(0x1c)
+  :fun ref "some_u8="(new_value): @_p.set_u8(0x1c, new_value, 0)
+
+  :fun some_i8: @_p.i8(0x1d)
+  :fun some_i8_if_set!: @_p.i8_if_set!(0x1d)
+  :fun ref "some_i8="(new_value): @_p.set_i8(0x1d, new_value, 0)
+
+  :fun ref some_text: @_p.text(0)
+  :fun ref some_text_if_set!: @_p.text_if_set!(0)
+  :fun ref "some_text="(new_value): @_p.set_text(0, new_value, "")
+
+  :fun ref some_data: @_p.data(1)
+  :fun ref some_data_if_set!: @_p.data_if_set!(1)
+  :fun ref "some_data="(new_value): @_p.set_data(1, new_value, b"")
+
+  :fun ref child: _Example.Child.Builder.from_pointer(@_p.struct(2, 2, 2))
+  :fun ref child_if_set!: _Example.Child.Builder.from_pointer(@_p.struct_if_set!(2, 2, 2))
+  :fun ref set_child_to_point_to_existing(existing _Example.Child.Builder): _Example.Child.Builder.from_pointer(@_p.set_struct_to_point_to_existing(2, existing._p))
+
+  :fun ref children: CapnProto.List.Builder(_Example.Child.Builder).from_pointer(@_p.list(3))
+  :fun ref children_if_set!: CapnProto.List.Builder(_Example.Child.Builder).from_pointer(@_p.list_if_set!(3))
+  :fun ref init_children(new_count)
+    CapnProto.List.Builder(_Example.Child.Builder).from_pointer(@_p.init_list(3, 2, 2, new_count))
+  :fun ref init_children_and_copy_data_from(existing CapnProto.List(_Example.Child))
+    list = CapnProto.List.Builder(_Example.Child.Builder).from_pointer(@_p.init_list(3, 2, 2, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
+  :fun ref trim_children(new_start, new_finish)
+    CapnProto.List.Builder(_Example.Child.Builder).from_pointer(@_p.trim_list(3, 2, 2, new_start, new_finish))
+
+  :fun is_foo: @_p.check_union(0x1e, 0)
+  :fun ref foo!: @_p.assert_union!(0x1e, 0), _Example.Root.AS_foo.Builder.from_pointer(@_p)
+  :fun ref foo_if_set!: @_p.assert_union!(0x1e, 0), _Example.Root.AS_foo.Builder.from_pointer(@_p)
+  :fun ref init_foo
+    @_p.clear_64(0x20) // some_u64
+    @_p.clear_32(0x28) // some_u32
+    @_p.clear_pointer(4) // txt
+    @_p.mark_union(0x1e, 0)
+    _Example.Root.AS_foo.Builder.from_pointer(@_p)
+
+  :fun is_bar: @_p.check_union(0x1e, 1)
+  :fun ref bar!: @_p.assert_union!(0x1e, 1), _Example.Root.AS_bar.Builder.from_pointer(@_p)
+  :fun ref bar_if_set!: @_p.assert_union!(0x1e, 1), _Example.Root.AS_bar.Builder.from_pointer(@_p)
+  :fun ref init_bar
+    @_p.clear_64(0x20) // some_f64
+    @_p.clear_32(0x28) // some_f32
+    @_p.clear_pointer(4) // blob
+    @_p.mark_union(0x1e, 1)
+    _Example.Root.AS_bar.Builder.from_pointer(@_p)
+
+:struct _Example.Root.AS_foo.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+  :fun as_reader: _Example.Root.AS_foo.read_from_pointer(@_p.as_reader)
+
+  :const capn_proto_data_word_count U16: 6
+  :const capn_proto_pointer_count U16: 5
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
+  :is TraceData
+  :fun trace_data(trace TraceData.Observer)
+    @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other _Example.Root.AS_foo) None
+    try @_p.set_u64(0x20, other.some_u64_if_set!, 0)
+    try @_p.set_u32(0x28, other.some_u32_if_set!, 0)
+    try @_p.set_text(4, "\(other.txt_if_set!)", "")
+
+  :fun some_u64: @_p.u64(0x20)
+  :fun some_u64_if_set!: @_p.u64_if_set!(0x20)
+  :fun ref "some_u64="(new_value): @_p.set_u64(0x20, new_value, 0)
+
+  :fun some_u32: @_p.u32(0x28)
+  :fun some_u32_if_set!: @_p.u32_if_set!(0x28)
+  :fun ref "some_u32="(new_value): @_p.set_u32(0x28, new_value, 0)
+
+  :fun ref txt: @_p.text(4)
+  :fun ref txt_if_set!: @_p.text_if_set!(4)
+  :fun ref "txt="(new_value): @_p.set_text(4, new_value, "")
+
+:struct _Example.Root.AS_bar.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+  :fun as_reader: _Example.Root.AS_bar.read_from_pointer(@_p.as_reader)
+
+  :const capn_proto_data_word_count U16: 6
+  :const capn_proto_pointer_count U16: 5
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
+  :is TraceData
+  :fun trace_data(trace TraceData.Observer)
+    @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other _Example.Root.AS_bar) None
+    try @_p.set_f64(0x20, other.some_f64_if_set!, 0.0)
+    try @_p.set_f32(0x28, other.some_f32_if_set!, 0.0)
+    try @_p.set_data(4, "\(other.blob_if_set!)".as_bytes, b"")
+
+  :fun some_f64: @_p.f64(0x20)
+  :fun some_f64_if_set!: @_p.f64_if_set!(0x20)
+  :fun ref "some_f64="(new_value): @_p.set_f64(0x20, new_value, 0.0)
+
+  :fun some_f32: @_p.f32(0x28)
+  :fun some_f32_if_set!: @_p.f32_if_set!(0x28)
+  :fun ref "some_f32="(new_value): @_p.set_f32(0x28, new_value, 0.0)
+
+  :fun ref blob: @_p.data(4)
+  :fun ref blob_if_set!: @_p.data_if_set!(4)
+  :fun ref "blob="(new_value): @_p.set_data(4, new_value, b"")
+
+:struct _Example.Child.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+  :fun as_reader: _Example.Child.read_from_pointer(@_p.as_reader)
+
+  :const capn_proto_data_word_count U16: 2
+  :const capn_proto_pointer_count U16: 2
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
+  :is TraceData
+  :fun trace_data(trace TraceData.Observer)
+    @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other _Example.Child) None
+    try @_p.set_u64(0x0, other.a_if_set!, 0)
+    try @_p.set_u64(0x8, other.b_if_set!, 0)
+    try @_p.set_text(0, "\(other.name_if_set!)", "")
+    try (other_referenced = other.referenced_if_set!, @referenced.copy_data_from(other_referenced))
+
+  :fun a: @_p.u64(0x0)
+  :fun a_if_set!: @_p.u64_if_set!(0x0)
+  :fun ref "a="(new_value): @_p.set_u64(0x0, new_value, 0)
+
+  :fun b: @_p.u64(0x8)
+  :fun b_if_set!: @_p.u64_if_set!(0x8)
+  :fun ref "b="(new_value): @_p.set_u64(0x8, new_value, 0)
+
+  :fun ref name: @_p.text(0)
+  :fun ref name_if_set!: @_p.text_if_set!(0)
+  :fun ref "name="(new_value): @_p.set_text(0, new_value, "")
+
+  :fun ref referenced: _Example.Child.Builder.from_pointer(@_p.struct(1, 2, 2))
+  :fun ref referenced_if_set!: _Example.Child.Builder.from_pointer(@_p.struct_if_set!(1, 2, 2))
+  :fun ref set_referenced_to_point_to_existing(existing _Example.Child.Builder): _Example.Child.Builder.from_pointer(@_p.set_struct_to_point_to_existing(1, existing._p))

--- a/src/CapnProto.List.savi
+++ b/src/CapnProto.List.savi
@@ -16,6 +16,10 @@
     :yields A
     @_p.each -> (p | yield A.read_from_pointer(p))
 
+  :fun each_with_index
+    :yields A
+    @_p.each_with_index -> (p, i | yield (A.read_from_pointer(p), i.usize))
+
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     trace.array(@_p.absolute_address - 8) -> (
@@ -40,3 +44,7 @@
   :fun ref each
     :yields A
     @_p.each -> (p | yield A.from_pointer(p))
+
+  :fun ref each_with_index
+    :yields A
+    @_p.each_with_index -> (p, i | yield (A.from_pointer(p), i.usize))

--- a/src/CapnProto.Meta.capnp.savi
+++ b/src/CapnProto.Meta.capnp.savi
@@ -1103,6 +1103,22 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Node) None
+    try @_p.set_u64(0x0, other.id_if_set!, 0)
+    try @_p.set_text(0, "\(other.display_name_if_set!)", "")
+    try @_p.set_u32(0x8, other.display_name_prefix_length_if_set!, 0)
+    try @_p.set_u64(0x10, other.scope_id_if_set!, 0)
+    try @init_nested_nodes_and_copy_data_from(other.nested_nodes_if_set!)
+    try @init_annotations_and_copy_data_from(other.annotations_if_set!)
+    if other.is_file @init_file
+    try (other_struct = other.struct!, @init_struct.copy_data_from(other_struct))
+    try (other_enum = other.enum!, @init_enum.copy_data_from(other_enum))
+    try (other_interface = other.interface!, @init_interface.copy_data_from(other_interface))
+    try (other_const = other.const!, @init_const.copy_data_from(other_const))
+    try (other_annotation = other.annotation!, @init_annotation.copy_data_from(other_annotation))
+    try @init_parameters_and_copy_data_from(other.parameters_if_set!)
+    try @_p.set_bool(0x24, 0b00000001, Bool[other.is_generic_if_set!])
+
   :fun id: @_p.u64(0x0)
   :fun id_if_set!: @_p.u64_if_set!(0x0)
   :fun ref "id="(new_value): @_p.set_u64(0x0, new_value, 0)
@@ -1123,6 +1139,13 @@
   :fun ref nested_nodes_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_nested_nodes(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).from_pointer(@_p.init_list(1, 1, 1, new_count))
+  :fun ref init_nested_nodes_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.Node.NestedNode))
+    list = CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).from_pointer(@_p.init_list(1, 1, 1, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_nested_nodes(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).from_pointer(@_p.trim_list(1, 1, 1, new_start, new_finish))
 
@@ -1130,6 +1153,13 @@
   :fun ref annotations_if_set!: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list_if_set!(2))
   :fun ref init_annotations(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(2, 1, 2, new_count))
+  :fun ref init_annotations_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.Annotation))
+    list = CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(2, 1, 2, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_annotations(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.trim_list(2, 1, 2, new_start, new_finish))
 
@@ -1204,6 +1234,13 @@
   :fun ref parameters_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list_if_set!(5))
   :fun ref init_parameters(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.init_list(5, 0, 1, new_count))
+  :fun ref init_parameters_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.Node.Parameter))
+    list = CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.init_list(5, 0, 1, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_parameters(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.trim_list(5, 0, 1, new_start, new_finish))
 
@@ -1223,6 +1260,15 @@
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other CapnProto.Meta.Node.AS_struct) None
+    try @_p.set_u16(0xe, other.data_word_count_if_set!, 0)
+    try @_p.set_u16(0x18, other.pointer_count_if_set!, 0)
+    try @_p.set_u16(0x1a, CapnProto.Meta.ElementSize[other.preferred_list_encoding_if_set!].u16, 0)
+    try @_p.set_bool(0x1c, 0b00000001, Bool[other.is_group_if_set!])
+    try @_p.set_u16(0x1e, other.discriminant_count_if_set!, 0)
+    try @_p.set_u32(0x20, other.discriminant_offset_if_set!, 0)
+    try @init_fields_and_copy_data_from(other.fields_if_set!)
 
   :fun data_word_count: @_p.u16(0xe)
   :fun data_word_count_if_set!: @_p.u16_if_set!(0xe)
@@ -1252,6 +1298,13 @@
   :fun ref fields_if_set!: CapnProto.List.Builder(CapnProto.Meta.Field.Builder).from_pointer(@_p.list_if_set!(3))
   :fun ref init_fields(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Field.Builder).from_pointer(@_p.init_list(3, 3, 4, new_count))
+  :fun ref init_fields_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.Field))
+    list = CapnProto.List.Builder(CapnProto.Meta.Field.Builder).from_pointer(@_p.init_list(3, 3, 4, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_fields(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Field.Builder).from_pointer(@_p.trim_list(3, 3, 4, new_start, new_finish))
 
@@ -1268,10 +1321,20 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Node.AS_enum) None
+    try @init_enumerants_and_copy_data_from(other.enumerants_if_set!)
+
   :fun ref enumerants: CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.list(3))
   :fun ref enumerants_if_set!: CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.list_if_set!(3))
   :fun ref init_enumerants(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.init_list(3, 1, 2, new_count))
+  :fun ref init_enumerants_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.Enumerant))
+    list = CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.init_list(3, 1, 2, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_enumerants(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.trim_list(3, 1, 2, new_start, new_finish))
 
@@ -1288,10 +1351,21 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Node.AS_interface) None
+    try @init_methods_and_copy_data_from(other.methods_if_set!)
+    try @init_superclasses_and_copy_data_from(other.superclasses_if_set!)
+
   :fun ref methods: CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.list(3))
   :fun ref methods_if_set!: CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.list_if_set!(3))
   :fun ref init_methods(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.init_list(3, 3, 5, new_count))
+  :fun ref init_methods_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.Method))
+    list = CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.init_list(3, 3, 5, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_methods(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.trim_list(3, 3, 5, new_start, new_finish))
 
@@ -1299,6 +1373,13 @@
   :fun ref superclasses_if_set!: CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.list_if_set!(4))
   :fun ref init_superclasses(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.init_list(4, 1, 1, new_count))
+  :fun ref init_superclasses_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.Superclass))
+    list = CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.init_list(4, 1, 1, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_superclasses(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.trim_list(4, 1, 1, new_start, new_finish))
 
@@ -1314,6 +1395,10 @@
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other CapnProto.Meta.Node.AS_const) None
+    try (other_type = other.type_if_set!, @type.copy_data_from(other_type))
+    try (other_value = other.value_if_set!, @value.copy_data_from(other_value))
 
   :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(3, 3, 1))
   :fun ref type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(3, 3, 1))
@@ -1335,6 +1420,21 @@
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other CapnProto.Meta.Node.AS_annotation) None
+    try (other_type = other.type_if_set!, @type.copy_data_from(other_type))
+    try @_p.set_bool(0xe, 0b00000001, Bool[other.targets_file_if_set!])
+    try @_p.set_bool(0xe, 0b00000010, Bool[other.targets_const_if_set!])
+    try @_p.set_bool(0xe, 0b00000100, Bool[other.targets_enum_if_set!])
+    try @_p.set_bool(0xe, 0b00001000, Bool[other.targets_enumerant_if_set!])
+    try @_p.set_bool(0xe, 0b00010000, Bool[other.targets_struct_if_set!])
+    try @_p.set_bool(0xe, 0b00100000, Bool[other.targets_field_if_set!])
+    try @_p.set_bool(0xe, 0b01000000, Bool[other.targets_union_if_set!])
+    try @_p.set_bool(0xe, 0b10000000, Bool[other.targets_group_if_set!])
+    try @_p.set_bool(0xf, 0b00000001, Bool[other.targets_interface_if_set!])
+    try @_p.set_bool(0xf, 0b00000010, Bool[other.targets_method_if_set!])
+    try @_p.set_bool(0xf, 0b00000100, Bool[other.targets_param_if_set!])
+    try @_p.set_bool(0xf, 0b00001000, Bool[other.targets_annotation_if_set!])
 
   :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(3, 3, 1))
   :fun ref type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(3, 3, 1))
@@ -1401,6 +1501,9 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Node.Parameter) None
+    try @_p.set_text(0, "\(other.name_if_set!)", "")
+
   :fun ref name: @_p.text(0)
   :fun ref name_if_set!: @_p.text_if_set!(0)
   :fun ref "name="(new_value): @_p.set_text(0, new_value, "")
@@ -1417,6 +1520,10 @@
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other CapnProto.Meta.Node.NestedNode) None
+    try @_p.set_text(0, "\(other.name_if_set!)", "")
+    try @_p.set_u64(0x0, other.id_if_set!, 0)
 
   :fun ref name: @_p.text(0)
   :fun ref name_if_set!: @_p.text_if_set!(0)
@@ -1441,6 +1548,15 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Field) None
+    try @_p.set_text(0, "\(other.name_if_set!)", "")
+    try @_p.set_u16(0x0, other.code_order_if_set!, 0)
+    try @init_annotations_and_copy_data_from(other.annotations_if_set!)
+    try @_p.set_u16(0x2, other.discriminant_value_if_set!, 65535)
+    try (other_slot = other.slot!, @init_slot.copy_data_from(other_slot))
+    try (other_group = other.group!, @init_group.copy_data_from(other_group))
+    try (other_ordinal = other.ordinal_if_set!, @ordinal.copy_data_from(other_ordinal))
+
   :fun ref name: @_p.text(0)
   :fun ref name_if_set!: @_p.text_if_set!(0)
   :fun ref "name="(new_value): @_p.set_text(0, new_value, "")
@@ -1453,6 +1569,13 @@
   :fun ref annotations_if_set!: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_annotations(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
+  :fun ref init_annotations_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.Annotation))
+    list = CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_annotations(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.trim_list(1, 1, 2, new_start, new_finish))
 
@@ -1495,6 +1618,12 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Field.AS_slot) None
+    try @_p.set_u32(0x4, other.offset_if_set!, 0)
+    try (other_type = other.type_if_set!, @type.copy_data_from(other_type))
+    try (other_default_value = other.default_value_if_set!, @default_value.copy_data_from(other_default_value))
+    try @_p.set_bool(0x10, 0b00000001, Bool[other.had_explicit_default_if_set!])
+
   :fun offset: @_p.u32(0x4)
   :fun offset_if_set!: @_p.u32_if_set!(0x4)
   :fun ref "offset="(new_value): @_p.set_u32(0x4, new_value, 0)
@@ -1524,6 +1653,9 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Field.AS_group) None
+    try @_p.set_u64(0x10, other.type_id_if_set!, 0)
+
   :fun type_id: @_p.u64(0x10)
   :fun type_id_if_set!: @_p.u64_if_set!(0x10)
   :fun ref "type_id="(new_value): @_p.set_u64(0x10, new_value, 0)
@@ -1540,6 +1672,10 @@
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other CapnProto.Meta.Field.AS_ordinal) None
+    if other.is_implicit @init_implicit
+    try @_p.set_u16(0xc, other.explicit!, 0)
 
   :fun is_implicit: @_p.check_union(0xa, 0)
   :fun implicit!: @_p.assert_union!(0xa, 0), None
@@ -1569,6 +1705,11 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Enumerant) None
+    try @_p.set_text(0, "\(other.name_if_set!)", "")
+    try @_p.set_u16(0x0, other.code_order_if_set!, 0)
+    try @init_annotations_and_copy_data_from(other.annotations_if_set!)
+
   :fun ref name: @_p.text(0)
   :fun ref name_if_set!: @_p.text_if_set!(0)
   :fun ref "name="(new_value): @_p.set_text(0, new_value, "")
@@ -1581,6 +1722,13 @@
   :fun ref annotations_if_set!: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_annotations(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
+  :fun ref init_annotations_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.Annotation))
+    list = CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_annotations(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.trim_list(1, 1, 2, new_start, new_finish))
 
@@ -1596,6 +1744,10 @@
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other CapnProto.Meta.Superclass) None
+    try @_p.set_u64(0x0, other.id_if_set!, 0)
+    try (other_brand = other.brand_if_set!, @brand.copy_data_from(other_brand))
 
   :fun id: @_p.u64(0x0)
   :fun id_if_set!: @_p.u64_if_set!(0x0)
@@ -1618,6 +1770,16 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Method) None
+    try @_p.set_text(0, "\(other.name_if_set!)", "")
+    try @_p.set_u16(0x0, other.code_order_if_set!, 0)
+    try @_p.set_u64(0x8, other.param_struct_type_if_set!, 0)
+    try @_p.set_u64(0x10, other.result_struct_type_if_set!, 0)
+    try @init_annotations_and_copy_data_from(other.annotations_if_set!)
+    try (other_param_brand = other.param_brand_if_set!, @param_brand.copy_data_from(other_param_brand))
+    try (other_result_brand = other.result_brand_if_set!, @result_brand.copy_data_from(other_result_brand))
+    try @init_implicit_parameters_and_copy_data_from(other.implicit_parameters_if_set!)
+
   :fun ref name: @_p.text(0)
   :fun ref name_if_set!: @_p.text_if_set!(0)
   :fun ref "name="(new_value): @_p.set_text(0, new_value, "")
@@ -1638,6 +1800,13 @@
   :fun ref annotations_if_set!: CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_annotations(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
+  :fun ref init_annotations_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.Annotation))
+    list = CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_annotations(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.trim_list(1, 1, 2, new_start, new_finish))
 
@@ -1653,6 +1822,13 @@
   :fun ref implicit_parameters_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list_if_set!(4))
   :fun ref init_implicit_parameters(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.init_list(4, 0, 1, new_count))
+  :fun ref init_implicit_parameters_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.Node.Parameter))
+    list = CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.init_list(4, 0, 1, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_implicit_parameters(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.trim_list(4, 0, 1, new_start, new_finish))
 
@@ -1668,6 +1844,27 @@
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other CapnProto.Meta.Type) None
+    if other.is_void @init_void
+    if other.is_bool @init_bool
+    if other.is_int8 @init_int8
+    if other.is_int16 @init_int16
+    if other.is_int32 @init_int32
+    if other.is_int64 @init_int64
+    if other.is_uint8 @init_uint8
+    if other.is_uint16 @init_uint16
+    if other.is_uint32 @init_uint32
+    if other.is_uint64 @init_uint64
+    if other.is_float32 @init_float32
+    if other.is_float64 @init_float64
+    if other.is_text @init_text
+    if other.is_data @init_data
+    try (other_list = other.list!, @init_list.copy_data_from(other_list))
+    try (other_enum = other.enum!, @init_enum.copy_data_from(other_enum))
+    try (other_struct = other.struct!, @init_struct.copy_data_from(other_struct))
+    try (other_interface = other.interface!, @init_interface.copy_data_from(other_interface))
+    try (other_any_pointer = other.any_pointer!, @init_any_pointer.copy_data_from(other_any_pointer))
 
   :fun is_void: @_p.check_union(0x0, 0)
   :fun void!: @_p.assert_union!(0x0, 0), None
@@ -1822,6 +2019,9 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Type.AS_list) None
+    try (other_element_type = other.element_type_if_set!, @element_type.copy_data_from(other_element_type))
+
   :fun ref element_type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(0, 3, 1))
   :fun ref element_type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(0, 3, 1))
   :fun ref set_element_type_to_point_to_existing(existing CapnProto.Meta.Type.Builder): CapnProto.Meta.Type.Builder.from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
@@ -1838,6 +2038,10 @@
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other CapnProto.Meta.Type.AS_enum) None
+    try @_p.set_u64(0x8, other.type_id_if_set!, 0)
+    try (other_brand = other.brand_if_set!, @brand.copy_data_from(other_brand))
 
   :fun type_id: @_p.u64(0x8)
   :fun type_id_if_set!: @_p.u64_if_set!(0x8)
@@ -1860,6 +2064,10 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Type.AS_struct) None
+    try @_p.set_u64(0x8, other.type_id_if_set!, 0)
+    try (other_brand = other.brand_if_set!, @brand.copy_data_from(other_brand))
+
   :fun type_id: @_p.u64(0x8)
   :fun type_id_if_set!: @_p.u64_if_set!(0x8)
   :fun ref "type_id="(new_value): @_p.set_u64(0x8, new_value, 0)
@@ -1881,6 +2089,10 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Type.AS_interface) None
+    try @_p.set_u64(0x8, other.type_id_if_set!, 0)
+    try (other_brand = other.brand_if_set!, @brand.copy_data_from(other_brand))
+
   :fun type_id: @_p.u64(0x8)
   :fun type_id_if_set!: @_p.u64_if_set!(0x8)
   :fun ref "type_id="(new_value): @_p.set_u64(0x8, new_value, 0)
@@ -1901,6 +2113,11 @@
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other CapnProto.Meta.Type.AS_anyPointer) None
+    try (other_unconstrained = other.unconstrained!, @init_unconstrained.copy_data_from(other_unconstrained))
+    try (other_parameter = other.parameter!, @init_parameter.copy_data_from(other_parameter))
+    try (other_implicit_method_parameter = other.implicit_method_parameter!, @init_implicit_method_parameter.copy_data_from(other_implicit_method_parameter))
 
   :fun is_unconstrained: @_p.check_union(0x8, 0)
   :fun ref unconstrained!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained.Builder.from_pointer(@_p)
@@ -1938,6 +2155,12 @@
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained) None
+    if other.is_any_kind @init_any_kind
+    if other.is_struct @init_struct
+    if other.is_list @init_list
+    if other.is_capability @init_capability
 
   :fun is_any_kind: @_p.check_union(0xa, 0)
   :fun any_kind!: @_p.assert_union!(0xa, 0), None
@@ -1980,6 +2203,10 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Type.AS_anyPointer.AS_parameter) None
+    try @_p.set_u64(0x10, other.scope_id_if_set!, 0)
+    try @_p.set_u16(0xa, other.parameter_index_if_set!, 0)
+
   :fun scope_id: @_p.u64(0x10)
   :fun scope_id_if_set!: @_p.u64_if_set!(0x10)
   :fun ref "scope_id="(new_value): @_p.set_u64(0x10, new_value, 0)
@@ -2001,6 +2228,9 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter) None
+    try @_p.set_u16(0xa, other.parameter_index_if_set!, 0)
+
   :fun parameter_index: @_p.u16(0xa)
   :fun parameter_index_if_set!: @_p.u16_if_set!(0xa)
   :fun ref "parameter_index="(new_value): @_p.set_u16(0xa, new_value, 0)
@@ -2018,10 +2248,20 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Brand) None
+    try @init_scopes_and_copy_data_from(other.scopes_if_set!)
+
   :fun ref scopes: CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.list(0))
   :fun ref scopes_if_set!: CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.list_if_set!(0))
   :fun ref init_scopes(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.init_list(0, 2, 1, new_count))
+  :fun ref init_scopes_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.Brand.Scope))
+    list = CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.init_list(0, 2, 1, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_scopes(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.trim_list(0, 2, 1, new_start, new_finish))
 
@@ -2038,6 +2278,11 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Brand.Scope) None
+    try @_p.set_u64(0x0, other.scope_id_if_set!, 0)
+    try @init_bind_and_copy_data_from(other.bind!)
+    if other.is_inherit @init_inherit
+
   :fun scope_id: @_p.u64(0x0)
   :fun scope_id_if_set!: @_p.u64_if_set!(0x0)
   :fun ref "scope_id="(new_value): @_p.set_u64(0x0, new_value, 0)
@@ -2048,6 +2293,14 @@
   :fun ref init_bind(new_count)
     @_p.mark_union(0x8, 0)
     CapnProto.List.Builder(CapnProto.Meta.Brand.Binding.Builder).from_pointer(@_p.init_list(0, 1, 1, new_count))
+  :fun ref init_bind_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.Brand.Binding))
+    @_p.mark_union(0x8, 0)
+    list = CapnProto.List.Builder(CapnProto.Meta.Brand.Binding.Builder).from_pointer(@_p.init_list(0, 1, 1, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
 
   :fun is_inherit: @_p.check_union(0x8, 1)
   :fun inherit!: @_p.assert_union!(0x8, 1), None
@@ -2068,6 +2321,10 @@
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other CapnProto.Meta.Brand.Binding) None
+    if other.is_unbound @init_unbound
+    try (other_type = other.type!, @init_type.copy_data_from(other_type))
 
   :fun is_unbound: @_p.check_union(0x0, 0)
   :fun unbound!: @_p.assert_union!(0x0, 0), None
@@ -2096,6 +2353,24 @@
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other CapnProto.Meta.Value) None
+    if other.is_void @init_void
+    try @_p.set_bool(0x2, 0b00000001, Bool[other.bool!])
+    try @_p.set_i8(0x2, other.int8!, 0)
+    try @_p.set_i16(0x2, other.int16!, 0)
+    try @_p.set_i32(0x4, other.int32!, 0)
+    try @_p.set_i64(0x8, other.int64!, 0)
+    try @_p.set_u8(0x2, other.uint8!, 0)
+    try @_p.set_u16(0x2, other.uint16!, 0)
+    try @_p.set_u32(0x4, other.uint32!, 0)
+    try @_p.set_u64(0x8, other.uint64!, 0)
+    try @_p.set_f32(0x4, other.float32!, 0.0)
+    try @_p.set_f64(0x8, other.float64!, 0.0)
+    try @_p.set_text(0, "\(other.text!)", "")
+    try @_p.set_data(0, "\(other.data!)".as_bytes, b"")
+    try @_p.set_u16(0x2, other.enum!, 0)
+    if other.is_interface @init_interface
 
   :fun is_void: @_p.check_union(0x0, 0)
   :fun void!: @_p.assert_union!(0x0, 0), None
@@ -2257,6 +2532,11 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.Annotation) None
+    try @_p.set_u64(0x0, other.id_if_set!, 0)
+    try (other_value = other.value_if_set!, @value.copy_data_from(other_value))
+    try (other_brand = other.brand_if_set!, @brand.copy_data_from(other_brand))
+
   :fun id: @_p.u64(0x0)
   :fun id_if_set!: @_p.u64_if_set!(0x0)
   :fun ref "id="(new_value): @_p.set_u64(0x0, new_value, 0)
@@ -2282,10 +2562,21 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.CodeGeneratorRequest) None
+    try @init_nodes_and_copy_data_from(other.nodes_if_set!)
+    try @init_requested_files_and_copy_data_from(other.requested_files_if_set!)
+
   :fun ref nodes: CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.list(0))
   :fun ref nodes_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.list_if_set!(0))
   :fun ref init_nodes(new_count)
     CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.init_list(0, 5, 6, new_count))
+  :fun ref init_nodes_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.Node))
+    list = CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.init_list(0, 5, 6, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_nodes(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.trim_list(0, 5, 6, new_start, new_finish))
 
@@ -2293,6 +2584,13 @@
   :fun ref requested_files_if_set!: CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_requested_files(new_count)
     CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.init_list(1, 1, 2, new_count))
+  :fun ref init_requested_files_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.CodeGeneratorRequest.RequestedFile))
+    list = CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.init_list(1, 1, 2, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_requested_files(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.trim_list(1, 1, 2, new_start, new_finish))
 
@@ -2309,6 +2607,11 @@
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
+  :fun ref copy_data_from(other CapnProto.Meta.CodeGeneratorRequest.RequestedFile) None
+    try @_p.set_u64(0x0, other.id_if_set!, 0)
+    try @_p.set_text(0, "\(other.filename_if_set!)", "")
+    try @init_imports_and_copy_data_from(other.imports_if_set!)
+
   :fun id: @_p.u64(0x0)
   :fun id_if_set!: @_p.u64_if_set!(0x0)
   :fun ref "id="(new_value): @_p.set_u64(0x0, new_value, 0)
@@ -2321,6 +2624,13 @@
   :fun ref imports_if_set!: CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).from_pointer(@_p.list_if_set!(1))
   :fun ref init_imports(new_count)
     CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).from_pointer(@_p.init_list(1, 1, 1, new_count))
+  :fun ref init_imports_and_copy_data_from(existing CapnProto.List(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import))
+    list = CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).from_pointer(@_p.init_list(1, 1, 1, existing._p.count.usize))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_data_from(existing_item)
+    )
+    list
   :fun ref trim_imports(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).from_pointer(@_p.trim_list(1, 1, 1, new_start, new_finish))
 
@@ -2336,6 +2646,10 @@
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import) None
+    try @_p.set_u64(0x0, other.id_if_set!, 0)
+    try @_p.set_text(0, "\(other.name_if_set!)", "")
 
   :fun id: @_p.u64(0x0)
   :fun id_if_set!: @_p.u64_if_set!(0x0)

--- a/src/CapnProto.Pointer.StructList.savi
+++ b/src/CapnProto.Pointer.StructList.savi
@@ -165,6 +165,8 @@
 
   :fun _element_byte_size: (@_data_word_count.u32 + @_pointer_count.u32) * 8
 
+  :fun count: @_list_count
+
   :fun "[]!"(n U32)
     error! unless n < @_list_count
 
@@ -175,13 +177,17 @@
     )
 
   :fun each
+    @each_with_index -> (item, n | yield item)
+
+  :fun each_with_index
     @_list_count.times -> (n |
       try (
         byte_offset = @_byte_offset +! @_element_byte_size *! n
-
-        yield CapnProto.Pointer.Struct._new(
+        item = CapnProto.Pointer.Struct._new(
           @_segment, byte_offset, @_data_word_count, @_pointer_count
         )
+
+        yield (item, n)
       )
     )
 
@@ -275,6 +281,8 @@
       @
     )
 
+  :fun count: @_list_count
+
   :fun ref "[]!"(n U32)
     error! unless n < @_list_count
 
@@ -286,13 +294,16 @@
     )
 
   :fun ref each
+    @each_with_index -> (item, n | yield item)
+
+  :fun ref each_with_index
     @_list_count.times -> (n |
       try (
-        byte_offset = @_byte_offset
-          +! (@_data_word_count.u32 +! @_pointer_count.u32) *! n *! 8
-
-        yield CapnProto.Pointer.Struct.Builder._new(
+        byte_offset = @_byte_offset +! @_element_byte_size *! n
+        item = CapnProto.Pointer.Struct.Builder._new(
           @_segment, byte_offset, @_data_word_count, @_pointer_count
         )
+
+        yield (item, n)
       )
     )

--- a/src/capnpc-savi/_Gen.savi
+++ b/src/capnpc-savi/_Gen.savi
@@ -219,8 +219,9 @@
       )
     )
 
-    // Emit data tracing method.
+    // Emit data tracing methods.
     @_emit_trace_data(node, is_builder)
+    if is_builder @_emit_copy_data_from(node)
 
     // Emit field accessor methods.
     fields = try (node.struct!.fields | return)
@@ -232,6 +233,7 @@
       if is_builder (
         try @_emit_field_setter!(node, field)
         try @_emit_field_list_initter!(node, field)
+        try @_emit_field_list_initter!(node, field, True)
         try @_emit_field_list_trimmer!(node, field)
         try @_emit_field_union_initter!(node, field)
       )
@@ -276,6 +278,48 @@
         @_out << "\n      try trace.property(\(name.format.literal), @\(name)\(suffix)!)"
       )
       @_out << "\n    )"
+    )
+
+  :fun ref _emit_copy_data_from(node CapnProto.Meta.Node)
+    // TODO: It should be possible to copy data (without knowing the schema
+    // of every type we're copying) at the underlying pointer level.
+    // This would be a more efficient and ultimately simpler way to copy data,
+    // but it would require additional time investment that isn't important now.
+
+    @_out << "\n\n  :fun ref copy_data_from(other \(@_node_scoped_name(node))) None"
+
+    try node.struct!.fields.each -> (field |
+      name String = "\(_TextCase.Snake[field.name])"
+      is_union = field.discriminant_value != field.no_discriminant
+      get_suffix = if is_union ("" | "_if_set")
+      init_prefix = if is_union ("init_" | "")
+
+      slot = try (field.slot! |
+        // If the field is not a slot, it must be a group.
+        @_out << "\n    try (other_\(name) = other.\(name)\(get_suffix)!, @\(init_prefix)\(name).copy_data_from(other_\(name)))"
+        next
+      )
+
+      case (
+      | slot.type.is_void |
+        if is_union (
+          @_out << "\n    if other.is_\(name) @init_\(name)"
+        )
+      | slot.type.is_struct |
+        @_out << "\n    try (other_\(name) = other.\(name)\(get_suffix)!, @\(init_prefix)\(name).copy_data_from(other_\(name)))"
+      | slot.type.is_text |
+        @_out << "\n    try "
+        @_emit_field_set_expr(field, "\"\\(other.\(name)\(get_suffix)!)\"") // TODO: avoid intermediate string copy
+      | slot.type.is_data |
+        @_out << "\n    try "
+        @_emit_field_set_expr(field, "\"\\(other.\(name)\(get_suffix)!)\".as_bytes") // TODO: avoid intermediate string copy
+      | slot.type.is_list |
+        @_out << "\n    try @init_\(name)_and_copy_data_from(other.\(name)\(get_suffix)!)"
+      | @_is_pointer_type(slot.type) | // TODO: handle other pointer types
+      |
+        @_out << "\n    try "
+        @_emit_field_set_expr(field, "other.\(name)\(get_suffix)!")
+      )
     )
 
   :fun ref _emit_field_getter(
@@ -344,6 +388,7 @@
   :fun ref _emit_field_list_initter!(
     node CapnProto.Meta.Node
     field CapnProto.Meta.Field
+    is_copy Bool = False
   )
     slot = field.slot!
     type = slot.type
@@ -351,9 +396,19 @@
     struct_type = type.list!.element_type.struct!
     struct = @_find_node!(struct_type.type_id).struct!
 
+    suffix = ""
+    params = "new_count"
+    init_list_args = "new_count"
+
+    if is_copy (
+      suffix = "_and_copy_data_from"
+      params = "existing \(@_type_name(type, False))"
+      init_list_args = "existing._p.count.usize"
+    )
+
     @_out << "\n  :fun ref init_\(
       _TextCase.Snake[field.name]
-    )(new_count)"
+    )\(suffix)(\(params))"
 
     is_union = field.discriminant_value != field.no_discriminant
     if is_union (
@@ -367,7 +422,9 @@
       )
     )
 
-    @_out << "\n    \(
+    @_out << "\n    "
+    if is_copy @_out << "list = "
+    @_out << "\(
       @_type_name(type, True)
     ).from_pointer(@_p.init_list(\(
       slot.offset
@@ -375,7 +432,15 @@
       struct.data_word_count
     ), \(
       struct.pointer_count
-    ), new_count))"
+    ), \(init_list_args)))"
+
+    if is_copy (
+      @_out << "\n    existing.each_with_index -> (existing_item, index |"
+      @_out << "\n      new_item = try (list[index]! | next)"
+      @_out << "\n      new_item.copy_data_from(existing_item)"
+      @_out << "\n    )"
+      @_out << "\n    list"
+    )
 
   :fun ref _emit_field_list_trimmer!(
     node CapnProto.Meta.Node


### PR DESCRIPTION
This allows for a pattern in which a struct builder wants to copy data from a struct reader. For example, in a data processing framework, an output message may want to copy "header" data from the input message that initiated it.