### PR TITLE
Fix a bug in hole placement when freeing a first hole.

### DIFF
--- a/spec/CapnProto.Message.Builder.Spec.savi
+++ b/spec/CapnProto.Message.Builder.Spec.savi
@@ -263,6 +263,31 @@
     assert: buffers[0]!.size == 0x60
     assert: buffers[0]!.space == 0x4000
 
+  :it "correctly handles free-and-allocate in this regression test"
+    message = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
+    message.root.some_text = "foo" // first, allocate a small text chunk
+    message.root.some_text = "Now, allocate a larger text chunk"
+
+    buffers = message.take_val_buffers
+    assert: buffers.size == 1
+    assert: "\(buffers[0]!.format.xxd)" == "\
+      00000000: 0000 0000 0600 0500 0000 0000 0000 0000 ................\n\
+      00000010: 0000 0000 0000 0000 0000 0000 0000 0000 ................\n\
+      00000020: 0000 0000 0000 0000 0000 0000 0000 0000 ................\n\
+      00000030: 0000 0000 0000 0000 4500 0000 1201 0000 ........E.......\n\
+      00000040: 0000 0000 0000 0000 0000 0000 0000 0000 ................\n\
+      00000050: 0000 0000 0000 0000 0000 0000 0000 0000 ................\n\
+      00000060: 0000 0000 0000 0000 0000 0000 0600 0500 ................\n\
+      00000070: 0000 0000 0000 0000 0000 0000 0000 0000 ................\n\
+      00000080: 0000 0000 0000 0000 0000 0000 0000 0000 ................\n\
+      00000090: 0000 0000 0000 0000 0000 0000 0000 0000 ................\n\
+      000000a0: 0000 0000 0000 0000 0000 0000 0000 0000 ................\n\
+      000000b0: 0000 0000 0000 0000 0000 0000 0000 0000 ................\n\
+      000000c0: 0000 0000 0000 0000 4e6f 772c 2061 6c6c ........Now,.all\n\
+      000000d0: 6f63 6174 6520 6120 6c61 7267 6572 2074 ocate.a.larger.t\n\
+      000000e0: 6578 7420 6368 756e 6b00 0000 0000 0000 ext.chunk.......\n\
+    "
+
   :it "lets you take the resulting message as a val"
     builder = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
     builder.root.some_text = "foo"

--- a/src/CapnProto.Segment.savi
+++ b/src/CapnProto.Segment.savi
@@ -155,8 +155,8 @@
       )
     )
 
-    // Otherwise, add it as a new hole at the end.
-    @_holes << Pair(U32).new(free_head, free_tail)
+    // Otherwise, add it as a new hole at the start.
+    try @_holes.insert_at!(0, Pair(U32).new(free_head, free_tail)) // TODO: Use `unshift(` instead of `try insert_at!(0`
     @
 
   :fun ref _take_buffer Bytes'iso


### PR DESCRIPTION
This bug was causing the hole placement to be wrong, such that taking the segment buffers and truncating the taken buffer at the last hole would not include
the entire buffer (because the last hole is the wrong hole)