### PR TITLE
Add initial support for generic types.

### DIFF
--- a/spec/CapnProto.Message.Builder.Spec.savi
+++ b/spec/CapnProto.Message.Builder.Spec.savi
@@ -181,6 +181,33 @@
     assert: root2.bar!.some_f32 == 43.3
     assert: "\(root2.bar!.blob)" == "!!"
 
+  :it "can represent generic types with type parameters"
+    message = CapnProto.Message.Builder(
+      _Example.Tree.Builder(
+        _Example.Key, _Example.Key.Builder
+        _Example.Child, _Example.Child.Builder
+      )
+    ).new(0x4000)
+    root = message.root
+
+    deep1 = root.left.left.left
+    deep2 = root.right.right.right
+
+    deep1.key.text = "foo"
+    deep1.value.a = 11
+    deep2.key.text = "bar"
+    deep2.value.a = 22
+
+    assert: "\(deep1.key.text)" == "foo"
+    assert: deep1.value.a == 11
+    assert: "\(deep2.key.text)" == "bar"
+    assert: deep2.value.a == 22
+
+    assert: "\(deep1.as_reader.key.text)" == "foo"
+    assert: deep1.as_reader.value.a == 11
+    assert: "\(deep2.as_reader.key.text)" == "bar"
+    assert: deep2.as_reader.value.a == 22
+
   :it "lets you point two parents to the same child struct in memory"
     message = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
     root = message.root

--- a/spec/_Example.capnp
+++ b/spec/_Example.capnp
@@ -42,3 +42,14 @@ struct Child {
 
   referenced @3 :Child;
 }
+
+struct Tree(K, V) {
+  left @0 :Tree(K, V);
+  right @1 :Tree(K, V);
+  key @2 :K;
+  value @3 :V;
+}
+
+struct Key {
+  text @0 :Text;
+}

--- a/spec/_Example.capnp.savi
+++ b/spec/_Example.capnp.savi
@@ -156,6 +156,57 @@
   :fun referenced: _Example.Child.read_from_pointer(@_p.struct(1))
   :fun referenced_if_set!: _Example.Child.read_from_pointer(@_p.struct_if_set!(1))
 
+:struct box _Example.Tree(
+  K CapnProto.Pointer.Struct.Type
+  V CapnProto.Pointer.Struct.Type
+)
+  :let _p CapnProto.Pointer.Struct
+  :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
+
+  :const capn_proto_data_word_count U16: 0
+  :const capn_proto_pointer_count U16: 4
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
+  :is TraceData
+  :fun trace_data(trace TraceData.Observer)
+    trace.object(@_p.absolute_address) -> (
+      try trace.property("left", @left_if_set!)
+      try trace.property("right", @right_if_set!)
+      try trace.property("key", @key_if_set!)
+      try trace.property("value", @value_if_set!)
+    )
+
+  :fun left: _Example.Tree(K, V).read_from_pointer(@_p.struct(0))
+  :fun left_if_set!: _Example.Tree(K, V).read_from_pointer(@_p.struct_if_set!(0))
+
+  :fun right: _Example.Tree(K, V).read_from_pointer(@_p.struct(1))
+  :fun right_if_set!: _Example.Tree(K, V).read_from_pointer(@_p.struct_if_set!(1))
+
+  :fun key: K.read_from_pointer(@_p.struct(2))
+  :fun key_if_set!: K.read_from_pointer(@_p.struct_if_set!(2))
+
+  :fun value: V.read_from_pointer(@_p.struct(3))
+  :fun value_if_set!: V.read_from_pointer(@_p.struct_if_set!(3))
+
+:struct box _Example.Key
+  :let _p CapnProto.Pointer.Struct
+  :new box read_from_pointer(@_p)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val): @_p = p
+
+  :const capn_proto_data_word_count U16: 0
+  :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
+  :is TraceData
+  :fun trace_data(trace TraceData.Observer)
+    trace.object(@_p.absolute_address) -> (
+      try trace.property("text", @text_if_set!)
+    )
+
+  :fun text: @_p.text(0)
+  :fun text_if_set!: @_p.text_if_set!(0)
+
 :struct _Example.Root.Builder
   :let _p CapnProto.Pointer.Struct.Builder
   :new from_pointer(@_p)
@@ -357,3 +408,59 @@
   :fun ref referenced: _Example.Child.Builder.from_pointer(@_p.struct(1, 2, 2))
   :fun ref referenced_if_set!: _Example.Child.Builder.from_pointer(@_p.struct_if_set!(1, 2, 2))
   :fun ref set_referenced_to_point_to_existing(existing _Example.Child.Builder): _Example.Child.Builder.from_pointer(@_p.set_struct_to_point_to_existing(1, existing._p))
+
+:struct _Example.Tree.Builder(
+  K CapnProto.Pointer.Struct.Type
+  K_Builder CapnProto.Pointer.Struct.Builder.Type
+  V CapnProto.Pointer.Struct.Type
+  V_Builder CapnProto.Pointer.Struct.Builder.Type
+)
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+  :fun as_reader: _Example.Tree(K, V).read_from_pointer(@_p.as_reader)
+
+  :const capn_proto_data_word_count U16: 0
+  :const capn_proto_pointer_count U16: 4
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
+  :is TraceData
+  :fun trace_data(trace TraceData.Observer)
+    @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other _Example.Tree(K, V)) None
+    try (other_left = other.left_if_set!, @left.copy_data_from(other_left))
+    try (other_right = other.right_if_set!, @right.copy_data_from(other_right))
+
+  :fun ref left: _Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(@_p.struct(0, 0, 4))
+  :fun ref left_if_set!: _Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(@_p.struct_if_set!(0, 0, 4))
+  :fun ref set_left_to_point_to_existing(existing _Example.Tree.Builder(K, K_Builder, V, V_Builder)): _Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
+
+  :fun ref right: _Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(@_p.struct(1, 0, 4))
+  :fun ref right_if_set!: _Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(@_p.struct_if_set!(1, 0, 4))
+  :fun ref set_right_to_point_to_existing(existing _Example.Tree.Builder(K, K_Builder, V, V_Builder)): _Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(@_p.set_struct_to_point_to_existing(1, existing._p))
+
+  :fun ref key: K_Builder.from_pointer(@_p.struct(2, K_Builder.capn_proto_data_word_count, K_Builder.capn_proto_pointer_count))
+  :fun ref key_if_set!: K_Builder.from_pointer(@_p.struct_if_set!(2, K_Builder.capn_proto_data_word_count, K_Builder.capn_proto_pointer_count))
+
+  :fun ref value: V_Builder.from_pointer(@_p.struct(3, V_Builder.capn_proto_data_word_count, V_Builder.capn_proto_pointer_count))
+  :fun ref value_if_set!: V_Builder.from_pointer(@_p.struct_if_set!(3, V_Builder.capn_proto_data_word_count, V_Builder.capn_proto_pointer_count))
+
+:struct _Example.Key.Builder
+  :let _p CapnProto.Pointer.Struct.Builder
+  :new from_pointer(@_p)
+  :fun as_reader: _Example.Key.read_from_pointer(@_p.as_reader)
+
+  :const capn_proto_data_word_count U16: 0
+  :const capn_proto_pointer_count U16: 1
+  :fun capn_proto_address U64: @_p.capn_proto_address
+
+  :is TraceData
+  :fun trace_data(trace TraceData.Observer)
+    @as_reader.trace_data(trace)
+
+  :fun ref copy_data_from(other _Example.Key) None
+    try @_p.set_text(0, "\(other.text_if_set!)", "")
+
+  :fun ref text: @_p.text(0)
+  :fun ref text_if_set!: @_p.text_if_set!(0)
+  :fun ref "text="(new_value): @_p.set_text(0, new_value, "")

--- a/src/CapnProto.Message.savi
+++ b/src/CapnProto.Message.savi
@@ -1,8 +1,4 @@
-:trait box _MessageRoot
-  :new box read_from_pointer(p CapnProto.Pointer.Struct)
-  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val)
-
-:struct box CapnProto.Message(A _MessageRoot)
+:struct box CapnProto.Message(A CapnProto.Pointer.Struct.Type)
   :let _p CapnProto.Pointer.Struct
 
   :new box (@_p)
@@ -32,13 +28,7 @@
     value = segment._u64!(start_offset.u32)
     @new_val(_ParseStructPointer._parse_val!(segment, start_offset.u32, value))
 
-:trait _MessageBuilderRoot
-  :new from_pointer(p CapnProto.Pointer.Struct.Builder)
-
-  :const capn_proto_data_word_count U16: 0
-  :const capn_proto_pointer_count U16: 0
-
-:struct CapnProto.Message.Builder(A _MessageBuilderRoot)
+:struct CapnProto.Message.Builder(A CapnProto.Pointer.Struct.Builder.Type)
   :let _initial_size USize
   :let _segments CapnProto.Segments
 

--- a/src/CapnProto.Meta.capnp.savi
+++ b/src/CapnProto.Meta.capnp.savi
@@ -956,24 +956,24 @@
   :fun data_if_set!: @_p.assert_union!(0x0, 13), @_p.data_if_set!(0)
 
   :fun is_list: @_p.check_union(0x0, 14)
-  :fun list!: @_p.assert_union!(0x0, 14), None // UNHANDLED: anyPointer
-  :fun list_if_set!: @_p.assert_union!(0x0, 14), None // UNHANDLED: anyPointer
+  :fun list!: @_p.assert_union!(0x0, 14), None // UNHANDLED: non-parameter anyPointer
+  :fun list_if_set!: @_p.assert_union!(0x0, 14), None // UNHANDLED: non-parameter anyPointer
 
   :fun is_enum: @_p.check_union(0x0, 15)
   :fun enum!: @_p.assert_union!(0x0, 15), @_p.u16(0x2)
   :fun enum_if_set!: @_p.assert_union!(0x0, 15), @_p.u16_if_set!(0x2)
 
   :fun is_struct: @_p.check_union(0x0, 16)
-  :fun struct!: @_p.assert_union!(0x0, 16), None // UNHANDLED: anyPointer
-  :fun struct_if_set!: @_p.assert_union!(0x0, 16), None // UNHANDLED: anyPointer
+  :fun struct!: @_p.assert_union!(0x0, 16), None // UNHANDLED: non-parameter anyPointer
+  :fun struct_if_set!: @_p.assert_union!(0x0, 16), None // UNHANDLED: non-parameter anyPointer
 
   :fun is_interface: @_p.check_union(0x0, 17)
   :fun interface!: @_p.assert_union!(0x0, 17), None
   :fun interface_if_set!: @_p.assert_union!(0x0, 17), None
 
   :fun is_any_pointer: @_p.check_union(0x0, 18)
-  :fun any_pointer!: @_p.assert_union!(0x0, 18), None // UNHANDLED: anyPointer
-  :fun any_pointer_if_set!: @_p.assert_union!(0x0, 18), None // UNHANDLED: anyPointer
+  :fun any_pointer!: @_p.assert_union!(0x0, 18), None // UNHANDLED: non-parameter anyPointer
+  :fun any_pointer_if_set!: @_p.assert_union!(0x0, 18), None // UNHANDLED: non-parameter anyPointer
 
 :struct box CapnProto.Meta.Annotation
   :let _p CapnProto.Pointer.Struct
@@ -2484,11 +2484,11 @@
     @_p.data(0)
 
   :fun is_list: @_p.check_union(0x0, 14)
-  :fun ref list!: @_p.assert_union!(0x0, 14), None // UNHANDLED: anyPointer
-  :fun ref list_if_set!: @_p.assert_union!(0x0, 14), None // UNHANDLED: anyPointer
+  :fun ref list!: @_p.assert_union!(0x0, 14), None // UNHANDLED: non-parameter anyPointer
+  :fun ref list_if_set!: @_p.assert_union!(0x0, 14), None // UNHANDLED: non-parameter anyPointer
   :fun ref init_list(new_value None)
     @_p.mark_union(0x0, 14)
-    None // UNHANDLED: anyPointer
+    None // UNHANDLED: non-parameter anyPointer
 
   :fun is_enum: @_p.check_union(0x0, 15)
   :fun enum!: @_p.assert_union!(0x0, 15), @_p.u16(0x2)
@@ -2499,11 +2499,11 @@
     @_p.u16(0x2)
 
   :fun is_struct: @_p.check_union(0x0, 16)
-  :fun ref struct!: @_p.assert_union!(0x0, 16), None // UNHANDLED: anyPointer
-  :fun ref struct_if_set!: @_p.assert_union!(0x0, 16), None // UNHANDLED: anyPointer
+  :fun ref struct!: @_p.assert_union!(0x0, 16), None // UNHANDLED: non-parameter anyPointer
+  :fun ref struct_if_set!: @_p.assert_union!(0x0, 16), None // UNHANDLED: non-parameter anyPointer
   :fun ref init_struct(new_value None)
     @_p.mark_union(0x0, 16)
-    None // UNHANDLED: anyPointer
+    None // UNHANDLED: non-parameter anyPointer
 
   :fun is_interface: @_p.check_union(0x0, 17)
   :fun interface!: @_p.assert_union!(0x0, 17), None
@@ -2513,11 +2513,11 @@
     None
 
   :fun is_any_pointer: @_p.check_union(0x0, 18)
-  :fun ref any_pointer!: @_p.assert_union!(0x0, 18), None // UNHANDLED: anyPointer
-  :fun ref any_pointer_if_set!: @_p.assert_union!(0x0, 18), None // UNHANDLED: anyPointer
+  :fun ref any_pointer!: @_p.assert_union!(0x0, 18), None // UNHANDLED: non-parameter anyPointer
+  :fun ref any_pointer_if_set!: @_p.assert_union!(0x0, 18), None // UNHANDLED: non-parameter anyPointer
   :fun ref init_any_pointer(new_value None)
     @_p.mark_union(0x0, 18)
-    None // UNHANDLED: anyPointer
+    None // UNHANDLED: non-parameter anyPointer
 
 :struct CapnProto.Meta.Annotation.Builder
   :let _p CapnProto.Pointer.Struct.Builder

--- a/src/CapnProto.Pointer.Struct.savi
+++ b/src/CapnProto.Pointer.Struct.savi
@@ -101,6 +101,12 @@
     pointer._data_word_count.u64.bit_shl(32)          // C (A and B are zero)
       .bit_or(pointer._pointer_count.u64.bit_shl(48)) // D
 
+:trait box CapnProto.Pointer.Struct.Type
+  :new box read_from_pointer(p CapnProto.Pointer.Struct)
+  :new val read_val_from_pointer(p CapnProto.Pointer.Struct'val)
+
+  :is TraceData
+
 :struct box CapnProto.Pointer.Struct
   :let _segment CapnProto.Segment'box
   :let _byte_offset U32
@@ -220,6 +226,14 @@
     _ParseStructListPointer._parse!(
       @_segment, byte_offset, @_segment._u64!(byte_offset)
     )
+
+:trait CapnProto.Pointer.Struct.Builder.Type
+  :new from_pointer(p CapnProto.Pointer.Struct.Builder)
+
+  :const capn_proto_data_word_count U16: 0
+  :const capn_proto_pointer_count U16: 0
+
+  :is TraceData
 
 :struct CapnProto.Pointer.Struct.Builder
   :let _segment CapnProto.Segment

--- a/src/capnpc-savi/_Gen.savi
+++ b/src/capnpc-savi/_Gen.savi
@@ -97,9 +97,31 @@
         try @_find_node_scoped_name(t.struct!.type_id)
       )\(
         if is_builder (".Builder" | "")
+      )\(
+        try (
+          args Array(String) = []
+          // TODO: In what scenario is there more than one scope?
+          // TODO: In what scenario are there non-bind scopes?
+          t.struct!.brand.scopes[0]!.bind!.each -> (bind |
+            args.push(@_type_name(bind.type!, False))
+            if is_builder (
+              args.push(@_type_name(bind.type!, True))
+            )
+          )
+          "(\(String.join(args, ", ")))"
+        )
       )"
     | t.is_interface | "INTERFACES_NOT_IMPLEMENTED"
-    | t.is_any_pointer | "ANY_POINTER_NOT_IMPLEMENTED"
+    | t.is_any_pointer |
+      try (
+        parameter_ref = t.any_pointer!.parameter!
+        parameter_index = parameter_ref.parameter_index
+        parameters = @_find_node!(parameter_ref.scope_id).parameters
+        parameter = parameters[parameter_index.usize]!
+        "\(parameter.name)\(if is_builder "_Builder")"
+      |
+        "ANY_POINTER_NOT_IMPLEMENTED"
+      )
     | "NOT_IMPLEMENTED"
     )
 
@@ -176,6 +198,16 @@
     )\(
       if is_builder ".Builder"
     )"
+    if node.parameters.size > 0 (
+      @_out << "("
+      node.parameters.each -> (param |
+        @_out << "\n  \(param.name) CapnProto.Pointer.Struct.Type"
+        if is_builder (
+          @_out << "\n  \(param.name)_Builder CapnProto.Pointer.Struct.Builder.Type"
+        )
+      )
+      @_out << "\n)"
+    )
     @_out << "\n  :let _p CapnProto.Pointer.Struct\(
       if is_builder ".Builder"
     )"
@@ -186,6 +218,14 @@
     if is_builder (
       @_out << "\n  :fun as_reader: \(
         node_scoped_name
+      )\(
+        if node.parameters.size > 0 "\(
+          param_names Array(String) = []
+          node.parameters.each -> (param |
+            param_names.push("\(param.name)")
+          )
+          "(\(String.join(param_names, ", ")))"
+        )"
       ).read_from_pointer(@_p.as_reader)"
     |
       @_out << "\n  :new val read_val_from_pointer"
@@ -286,7 +326,17 @@
     // This would be a more efficient and ultimately simpler way to copy data,
     // but it would require additional time investment that isn't important now.
 
-    @_out << "\n\n  :fun ref copy_data_from(other \(@_node_scoped_name(node))) None"
+    @_out << "\n\n  :fun ref copy_data_from(other \(
+      @_node_scoped_name(node)
+    )\(
+      if node.parameters.size > 0 "\(
+        param_names Array(String) = []
+        node.parameters.each -> (param |
+          param_names.push("\(param.name)")
+        )
+        "(\(String.join(param_names, ", ")))"
+      )"
+    )) None"
 
     try node.struct!.fields.each -> (field |
       name String = "\(_TextCase.Snake[field.name])"
@@ -695,7 +745,24 @@
     | type.is_interface |
       @_out << "None // UNHANDLED: interface" // TODO: handle interfaces
     | type.is_any_pointer |
-      @_out << "None // UNHANDLED: anyPointer" // TODO: handle "any pointer"
+      try (
+        // Sometimes, anyPointer is a type parameter reference,
+        // and that's a case that we actually can handle.
+        parameter_ref = type.any_pointer!.parameter!
+        parameter_index = parameter_ref.parameter_index
+        parameters = @_find_node!(parameter_ref.scope_id).parameters
+        parameter = parameters[parameter_index.usize]!
+
+        @_out << "\(parameter.name)\(
+          if is_builder ("_Builder." | ".read_")
+        )from_pointer(@_p.struct\(suffix)(\(offset)\(
+          if is_builder ", \(
+            parameter.name)_Builder.capn_proto_data_word_count, \(
+            parameter.name)_Builder.capn_proto_pointer_count"
+        )))"
+      |
+        @_out << "None // UNHANDLED: non-parameter anyPointer" // TODO: handle this
+      )
     |
       @_out << "NOT_IMPLEMENTED"
     )


### PR DESCRIPTION
Now we can implement CapnProto structs that take
type parameters (which also must currently always be structs).