### PR TITLE
Add `copy_or_reference_data_from` methods to structs.

### DIFF
--- a/manifest.savi
+++ b/manifest.savi
@@ -4,6 +4,9 @@
   :dependency ByteStream v0
     :from "github:savi-lang/ByteStream"
 
+  :dependency Map v0
+    :from "github:savi-lang/Map"
+
 :manifest bin "spec"
   :copies CapnProto
   :sources "spec/*.savi"
@@ -13,9 +16,6 @@
     :depends on Map
     :depends on Time
     :depends on Timer
-
-  :transitive dependency Map v0
-    :from "github:savi-lang/Map"
 
   :transitive dependency Time v0
     :from "github:savi-lang/Time"

--- a/spec/CapnProto.Message.Builder.Spec.savi
+++ b/spec/CapnProto.Message.Builder.Spec.savi
@@ -270,6 +270,30 @@
     assert: root.children[1]!.referenced.b == 44
     assert: "\(root.children[1]!.referenced.name)" == "bar"
 
+    message2 = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
+    root2 = message2.root
+    cache = CapnProto.ReferenceCache.new
+
+    root2.copy_or_reference_data_from(root.as_reader, cache)
+
+    assert: root2.children.size == 4
+    assert: root2.children[0]!.referenced.a == 55
+    assert: root2.children[0]!.referenced.b == 66
+    assert: "\(root2.children[0]!.referenced.name)" == "baz"
+    assert: root2.children[1]!.referenced.a == 33
+    assert: root2.children[1]!.referenced.b == 44
+    assert: "\(root2.children[1]!.referenced.name)" == "bar"
+    assert: root2.children[2]!.referenced.a == 55
+    assert: root2.children[2]!.referenced.b == 66
+    assert: "\(root2.children[2]!.referenced.name)" == "baz"
+    assert: root2.children[3]!.referenced.a == 77
+    assert: root2.children[3]!.referenced.b == 88
+    assert: "\(root2.children[3]!.referenced.name)" == "qux"
+    assert: root2.children[0]!.referenced.capn_proto_absolute_address ==
+      root2.children[2]!.referenced.capn_proto_absolute_address
+    assert: root.children[0]!.referenced.capn_proto_absolute_address !=
+      root2.children[0]!.referenced.capn_proto_absolute_address
+
   :it "lets you take the resulting byte buffers"
     message = CapnProto.Message.Builder(_Example.Root.Builder).new(0x4000)
     buffers = message.take_val_buffers

--- a/spec/_Example.capnp.savi
+++ b/spec/_Example.capnp.savi
@@ -10,6 +10,7 @@
   :const capn_proto_data_word_count U16: 6
   :const capn_proto_pointer_count U16: 5
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -82,6 +83,7 @@
   :const capn_proto_data_word_count U16: 6
   :const capn_proto_pointer_count U16: 5
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -108,6 +110,7 @@
   :const capn_proto_data_word_count U16: 6
   :const capn_proto_pointer_count U16: 5
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -134,6 +137,7 @@
   :const capn_proto_data_word_count U16: 2
   :const capn_proto_pointer_count U16: 2
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -167,6 +171,7 @@
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 4
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -197,6 +202,7 @@
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -215,6 +221,7 @@
   :const capn_proto_data_word_count U16: 6
   :const capn_proto_pointer_count U16: 5
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -235,6 +242,22 @@
     try @init_children_and_copy_data_from(other.children_if_set!)
     try (other_foo = other.foo!, @init_foo.copy_data_from(other_foo))
     try (other_bar = other.bar!, @init_bar.copy_data_from(other_bar))
+
+  :fun ref copy_or_reference_data_from(other _Example.Root, cache CapnProto.ReferenceCache) None
+    try @_p.set_u64(0x0, other.some_u64_if_set!, 0)
+    try @_p.set_i64(0x8, other.some_i64_if_set!, 0)
+    try @_p.set_u32(0x10, other.some_u32_if_set!, 0)
+    try @_p.set_i32(0x14, other.some_i32_if_set!, 0)
+    try @_p.set_u16(0x18, other.some_u16_if_set!, 0)
+    try @_p.set_i16(0x1a, other.some_i16_if_set!, 0)
+    try @_p.set_u8(0x1c, other.some_u8_if_set!, 0)
+    try @_p.set_i8(0x1d, other.some_i8_if_set!, 0)
+    try @_p.set_text(0, "\(other.some_text_if_set!)", "")
+    try @_p.set_data(1, "\(other.some_data_if_set!)".as_bytes, b"")
+    try @copy_or_reference_child_data_from(other.child_if_set!, cache)
+    try @init_children_and_copy_or_reference_data_from(other.children_if_set!, cache)
+    try (other_foo = other.foo!, @init_foo.copy_or_reference_data_from(other_foo, cache))
+    try (other_bar = other.bar!, @init_bar.copy_or_reference_data_from(other_bar, cache))
 
   :fun some_u64: @_p.u64(0x0)
   :fun some_u64_if_set!: @_p.u64_if_set!(0x0)
@@ -279,6 +302,17 @@
   :fun ref child: _Example.Child.Builder.from_pointer(@_p.struct(2, 2, 2))
   :fun ref child_if_set!: _Example.Child.Builder.from_pointer(@_p.struct_if_set!(2, 2, 2))
   :fun ref set_child_to_point_to_existing(existing _Example.Child.Builder): _Example.Child.Builder.from_pointer(@_p.set_struct_to_point_to_existing(2, existing._p))
+  :fun ref copy_or_reference_child_data_from(other_field _Example.Child, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(2, 2, 2)
+    )
+    if is_new (
+      _Example.Child.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_child_to_point_to_existing(_Example.Child.Builder.from_pointer(p))
+    )
 
   :fun ref children: CapnProto.List.Builder(_Example.Child.Builder).from_pointer(@_p.list(3))
   :fun ref children_if_set!: CapnProto.List.Builder(_Example.Child.Builder).from_pointer(@_p.list_if_set!(3))
@@ -289,6 +323,13 @@
     existing.each_with_index -> (existing_item, index |
       new_item = try (list[index]! | next)
       new_item.copy_data_from(existing_item)
+    )
+    list
+  :fun ref init_children_and_copy_or_reference_data_from(existing CapnProto.List(_Example.Child), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(_Example.Child.Builder).from_pointer(@_p.init_list(3, 2, 2, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
     )
     list
   :fun ref trim_children(new_start, new_finish)
@@ -322,12 +363,18 @@
   :const capn_proto_data_word_count U16: 6
   :const capn_proto_pointer_count U16: 5
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
   :fun ref copy_data_from(other _Example.Root.AS_foo) None
+    try @_p.set_u64(0x20, other.some_u64_if_set!, 0)
+    try @_p.set_u32(0x28, other.some_u32_if_set!, 0)
+    try @_p.set_text(4, "\(other.txt_if_set!)", "")
+
+  :fun ref copy_or_reference_data_from(other _Example.Root.AS_foo, cache CapnProto.ReferenceCache) None
     try @_p.set_u64(0x20, other.some_u64_if_set!, 0)
     try @_p.set_u32(0x28, other.some_u32_if_set!, 0)
     try @_p.set_text(4, "\(other.txt_if_set!)", "")
@@ -352,12 +399,18 @@
   :const capn_proto_data_word_count U16: 6
   :const capn_proto_pointer_count U16: 5
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
   :fun ref copy_data_from(other _Example.Root.AS_bar) None
+    try @_p.set_f64(0x20, other.some_f64_if_set!, 0.0)
+    try @_p.set_f32(0x28, other.some_f32_if_set!, 0.0)
+    try @_p.set_data(4, "\(other.blob_if_set!)".as_bytes, b"")
+
+  :fun ref copy_or_reference_data_from(other _Example.Root.AS_bar, cache CapnProto.ReferenceCache) None
     try @_p.set_f64(0x20, other.some_f64_if_set!, 0.0)
     try @_p.set_f32(0x28, other.some_f32_if_set!, 0.0)
     try @_p.set_data(4, "\(other.blob_if_set!)".as_bytes, b"")
@@ -382,6 +435,7 @@
   :const capn_proto_data_word_count U16: 2
   :const capn_proto_pointer_count U16: 2
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -392,6 +446,12 @@
     try @_p.set_u64(0x8, other.b_if_set!, 0)
     try @_p.set_text(0, "\(other.name_if_set!)", "")
     try (other_referenced = other.referenced_if_set!, @referenced.copy_data_from(other_referenced))
+
+  :fun ref copy_or_reference_data_from(other _Example.Child, cache CapnProto.ReferenceCache) None
+    try @_p.set_u64(0x0, other.a_if_set!, 0)
+    try @_p.set_u64(0x8, other.b_if_set!, 0)
+    try @_p.set_text(0, "\(other.name_if_set!)", "")
+    try @copy_or_reference_referenced_data_from(other.referenced_if_set!, cache)
 
   :fun a: @_p.u64(0x0)
   :fun a_if_set!: @_p.u64_if_set!(0x0)
@@ -408,6 +468,17 @@
   :fun ref referenced: _Example.Child.Builder.from_pointer(@_p.struct(1, 2, 2))
   :fun ref referenced_if_set!: _Example.Child.Builder.from_pointer(@_p.struct_if_set!(1, 2, 2))
   :fun ref set_referenced_to_point_to_existing(existing _Example.Child.Builder): _Example.Child.Builder.from_pointer(@_p.set_struct_to_point_to_existing(1, existing._p))
+  :fun ref copy_or_reference_referenced_data_from(other_field _Example.Child, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(1, 2, 2)
+    )
+    if is_new (
+      _Example.Child.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_referenced_to_point_to_existing(_Example.Child.Builder.from_pointer(p))
+    )
 
 :struct _Example.Tree.Builder(
   K CapnProto.Pointer.Struct.Type
@@ -422,6 +493,7 @@
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 4
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -431,13 +503,39 @@
     try (other_left = other.left_if_set!, @left.copy_data_from(other_left))
     try (other_right = other.right_if_set!, @right.copy_data_from(other_right))
 
+  :fun ref copy_or_reference_data_from(other _Example.Tree(K, V), cache CapnProto.ReferenceCache) None
+    try @copy_or_reference_left_data_from(other.left_if_set!, cache)
+    try @copy_or_reference_right_data_from(other.right_if_set!, cache)
+
   :fun ref left: _Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(@_p.struct(0, 0, 4))
   :fun ref left_if_set!: _Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(@_p.struct_if_set!(0, 0, 4))
   :fun ref set_left_to_point_to_existing(existing _Example.Tree.Builder(K, K_Builder, V, V_Builder)): _Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
+  :fun ref copy_or_reference_left_data_from(other_field _Example.Tree(K, V), cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(0, 0, 4)
+    )
+    if is_new (
+      _Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_left_to_point_to_existing(_Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(p))
+    )
 
   :fun ref right: _Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(@_p.struct(1, 0, 4))
   :fun ref right_if_set!: _Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(@_p.struct_if_set!(1, 0, 4))
   :fun ref set_right_to_point_to_existing(existing _Example.Tree.Builder(K, K_Builder, V, V_Builder)): _Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(@_p.set_struct_to_point_to_existing(1, existing._p))
+  :fun ref copy_or_reference_right_data_from(other_field _Example.Tree(K, V), cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(1, 0, 4)
+    )
+    if is_new (
+      _Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_right_to_point_to_existing(_Example.Tree.Builder(K, K_Builder, V, V_Builder).from_pointer(p))
+    )
 
   :fun ref key: K_Builder.from_pointer(@_p.struct(2, K_Builder.capn_proto_data_word_count, K_Builder.capn_proto_pointer_count))
   :fun ref key_if_set!: K_Builder.from_pointer(@_p.struct_if_set!(2, K_Builder.capn_proto_data_word_count, K_Builder.capn_proto_pointer_count))
@@ -453,12 +551,16 @@
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
   :fun ref copy_data_from(other _Example.Key) None
+    try @_p.set_text(0, "\(other.text_if_set!)", "")
+
+  :fun ref copy_or_reference_data_from(other _Example.Key, cache CapnProto.ReferenceCache) None
     try @_p.set_text(0, "\(other.text_if_set!)", "")
 
   :fun ref text: @_p.text(0)

--- a/src/CapnProto.Meta.capnp.savi
+++ b/src/CapnProto.Meta.capnp.savi
@@ -10,6 +10,7 @@
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -86,6 +87,7 @@
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -128,6 +130,7 @@
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -146,6 +149,7 @@
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -168,6 +172,7 @@
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -190,6 +195,7 @@
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -256,6 +262,7 @@
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -274,6 +281,7 @@
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -296,6 +304,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :const no_discriminant U16: 65535
 
@@ -342,6 +351,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -372,6 +382,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -390,6 +401,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -414,6 +426,7 @@
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -440,6 +453,7 @@
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -462,6 +476,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 5
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -508,6 +523,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -617,6 +633,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -635,6 +652,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -657,6 +675,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -679,6 +698,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -701,6 +721,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -730,6 +751,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -764,6 +786,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -786,6 +809,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -804,6 +828,7 @@
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -822,6 +847,7 @@
   :const capn_proto_data_word_count U16: 2
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -850,6 +876,7 @@
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -874,6 +901,7 @@
   :const capn_proto_data_word_count U16: 2
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -983,6 +1011,7 @@
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1028,6 +1057,7 @@
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 2
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1050,6 +1080,7 @@
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1076,6 +1107,7 @@
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1098,6 +1130,7 @@
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1117,6 +1150,22 @@
     try (other_const = other.const!, @init_const.copy_data_from(other_const))
     try (other_annotation = other.annotation!, @init_annotation.copy_data_from(other_annotation))
     try @init_parameters_and_copy_data_from(other.parameters_if_set!)
+    try @_p.set_bool(0x24, 0b00000001, Bool[other.is_generic_if_set!])
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Node, cache CapnProto.ReferenceCache) None
+    try @_p.set_u64(0x0, other.id_if_set!, 0)
+    try @_p.set_text(0, "\(other.display_name_if_set!)", "")
+    try @_p.set_u32(0x8, other.display_name_prefix_length_if_set!, 0)
+    try @_p.set_u64(0x10, other.scope_id_if_set!, 0)
+    try @init_nested_nodes_and_copy_or_reference_data_from(other.nested_nodes_if_set!, cache)
+    try @init_annotations_and_copy_or_reference_data_from(other.annotations_if_set!, cache)
+    if other.is_file @init_file
+    try (other_struct = other.struct!, @init_struct.copy_or_reference_data_from(other_struct, cache))
+    try (other_enum = other.enum!, @init_enum.copy_or_reference_data_from(other_enum, cache))
+    try (other_interface = other.interface!, @init_interface.copy_or_reference_data_from(other_interface, cache))
+    try (other_const = other.const!, @init_const.copy_or_reference_data_from(other_const, cache))
+    try (other_annotation = other.annotation!, @init_annotation.copy_or_reference_data_from(other_annotation, cache))
+    try @init_parameters_and_copy_or_reference_data_from(other.parameters_if_set!, cache)
     try @_p.set_bool(0x24, 0b00000001, Bool[other.is_generic_if_set!])
 
   :fun id: @_p.u64(0x0)
@@ -1146,6 +1195,13 @@
       new_item.copy_data_from(existing_item)
     )
     list
+  :fun ref init_nested_nodes_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.Node.NestedNode), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).from_pointer(@_p.init_list(1, 1, 1, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
+    )
+    list
   :fun ref trim_nested_nodes(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Node.NestedNode.Builder).from_pointer(@_p.trim_list(1, 1, 1, new_start, new_finish))
 
@@ -1158,6 +1214,13 @@
     existing.each_with_index -> (existing_item, index |
       new_item = try (list[index]! | next)
       new_item.copy_data_from(existing_item)
+    )
+    list
+  :fun ref init_annotations_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.Annotation), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(2, 1, 2, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
     )
     list
   :fun ref trim_annotations(new_start, new_finish)
@@ -1241,6 +1304,13 @@
       new_item.copy_data_from(existing_item)
     )
     list
+  :fun ref init_parameters_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.Node.Parameter), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.init_list(5, 0, 1, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
+    )
+    list
   :fun ref trim_parameters(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.trim_list(5, 0, 1, new_start, new_finish))
 
@@ -1256,6 +1326,7 @@
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1269,6 +1340,15 @@
     try @_p.set_u16(0x1e, other.discriminant_count_if_set!, 0)
     try @_p.set_u32(0x20, other.discriminant_offset_if_set!, 0)
     try @init_fields_and_copy_data_from(other.fields_if_set!)
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Node.AS_struct, cache CapnProto.ReferenceCache) None
+    try @_p.set_u16(0xe, other.data_word_count_if_set!, 0)
+    try @_p.set_u16(0x18, other.pointer_count_if_set!, 0)
+    try @_p.set_u16(0x1a, CapnProto.Meta.ElementSize[other.preferred_list_encoding_if_set!].u16, 0)
+    try @_p.set_bool(0x1c, 0b00000001, Bool[other.is_group_if_set!])
+    try @_p.set_u16(0x1e, other.discriminant_count_if_set!, 0)
+    try @_p.set_u32(0x20, other.discriminant_offset_if_set!, 0)
+    try @init_fields_and_copy_or_reference_data_from(other.fields_if_set!, cache)
 
   :fun data_word_count: @_p.u16(0xe)
   :fun data_word_count_if_set!: @_p.u16_if_set!(0xe)
@@ -1305,6 +1385,13 @@
       new_item.copy_data_from(existing_item)
     )
     list
+  :fun ref init_fields_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.Field), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.Field.Builder).from_pointer(@_p.init_list(3, 3, 4, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
+    )
+    list
   :fun ref trim_fields(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Field.Builder).from_pointer(@_p.trim_list(3, 3, 4, new_start, new_finish))
 
@@ -1316,6 +1403,7 @@
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1323,6 +1411,9 @@
 
   :fun ref copy_data_from(other CapnProto.Meta.Node.AS_enum) None
     try @init_enumerants_and_copy_data_from(other.enumerants_if_set!)
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Node.AS_enum, cache CapnProto.ReferenceCache) None
+    try @init_enumerants_and_copy_or_reference_data_from(other.enumerants_if_set!, cache)
 
   :fun ref enumerants: CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.list(3))
   :fun ref enumerants_if_set!: CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.list_if_set!(3))
@@ -1333,6 +1424,13 @@
     existing.each_with_index -> (existing_item, index |
       new_item = try (list[index]! | next)
       new_item.copy_data_from(existing_item)
+    )
+    list
+  :fun ref init_enumerants_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.Enumerant), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.Enumerant.Builder).from_pointer(@_p.init_list(3, 1, 2, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
     )
     list
   :fun ref trim_enumerants(new_start, new_finish)
@@ -1346,6 +1444,7 @@
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1354,6 +1453,10 @@
   :fun ref copy_data_from(other CapnProto.Meta.Node.AS_interface) None
     try @init_methods_and_copy_data_from(other.methods_if_set!)
     try @init_superclasses_and_copy_data_from(other.superclasses_if_set!)
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Node.AS_interface, cache CapnProto.ReferenceCache) None
+    try @init_methods_and_copy_or_reference_data_from(other.methods_if_set!, cache)
+    try @init_superclasses_and_copy_or_reference_data_from(other.superclasses_if_set!, cache)
 
   :fun ref methods: CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.list(3))
   :fun ref methods_if_set!: CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.list_if_set!(3))
@@ -1364,6 +1467,13 @@
     existing.each_with_index -> (existing_item, index |
       new_item = try (list[index]! | next)
       new_item.copy_data_from(existing_item)
+    )
+    list
+  :fun ref init_methods_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.Method), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.Method.Builder).from_pointer(@_p.init_list(3, 3, 5, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
     )
     list
   :fun ref trim_methods(new_start, new_finish)
@@ -1380,6 +1490,13 @@
       new_item.copy_data_from(existing_item)
     )
     list
+  :fun ref init_superclasses_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.Superclass), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.init_list(4, 1, 1, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
+    )
+    list
   :fun ref trim_superclasses(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Superclass.Builder).from_pointer(@_p.trim_list(4, 1, 1, new_start, new_finish))
 
@@ -1391,6 +1508,7 @@
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1400,13 +1518,39 @@
     try (other_type = other.type_if_set!, @type.copy_data_from(other_type))
     try (other_value = other.value_if_set!, @value.copy_data_from(other_value))
 
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Node.AS_const, cache CapnProto.ReferenceCache) None
+    try @copy_or_reference_type_data_from(other.type_if_set!, cache)
+    try @copy_or_reference_value_data_from(other.value_if_set!, cache)
+
   :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(3, 3, 1))
   :fun ref type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(3, 3, 1))
   :fun ref set_type_to_point_to_existing(existing CapnProto.Meta.Type.Builder): CapnProto.Meta.Type.Builder.from_pointer(@_p.set_struct_to_point_to_existing(3, existing._p))
+  :fun ref copy_or_reference_type_data_from(other_field CapnProto.Meta.Type, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(3, 3, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Type.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_type_to_point_to_existing(CapnProto.Meta.Type.Builder.from_pointer(p))
+    )
 
   :fun ref value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(4, 2, 1))
   :fun ref value_if_set!: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct_if_set!(4, 2, 1))
   :fun ref set_value_to_point_to_existing(existing CapnProto.Meta.Value.Builder): CapnProto.Meta.Value.Builder.from_pointer(@_p.set_struct_to_point_to_existing(4, existing._p))
+  :fun ref copy_or_reference_value_data_from(other_field CapnProto.Meta.Value, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(4, 2, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Value.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_value_to_point_to_existing(CapnProto.Meta.Value.Builder.from_pointer(p))
+    )
 
 :struct CapnProto.Meta.Node.AS_annotation.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1416,6 +1560,7 @@
   :const capn_proto_data_word_count U16: 5
   :const capn_proto_pointer_count U16: 6
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1436,9 +1581,35 @@
     try @_p.set_bool(0xf, 0b00000100, Bool[other.targets_param_if_set!])
     try @_p.set_bool(0xf, 0b00001000, Bool[other.targets_annotation_if_set!])
 
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Node.AS_annotation, cache CapnProto.ReferenceCache) None
+    try @copy_or_reference_type_data_from(other.type_if_set!, cache)
+    try @_p.set_bool(0xe, 0b00000001, Bool[other.targets_file_if_set!])
+    try @_p.set_bool(0xe, 0b00000010, Bool[other.targets_const_if_set!])
+    try @_p.set_bool(0xe, 0b00000100, Bool[other.targets_enum_if_set!])
+    try @_p.set_bool(0xe, 0b00001000, Bool[other.targets_enumerant_if_set!])
+    try @_p.set_bool(0xe, 0b00010000, Bool[other.targets_struct_if_set!])
+    try @_p.set_bool(0xe, 0b00100000, Bool[other.targets_field_if_set!])
+    try @_p.set_bool(0xe, 0b01000000, Bool[other.targets_union_if_set!])
+    try @_p.set_bool(0xe, 0b10000000, Bool[other.targets_group_if_set!])
+    try @_p.set_bool(0xf, 0b00000001, Bool[other.targets_interface_if_set!])
+    try @_p.set_bool(0xf, 0b00000010, Bool[other.targets_method_if_set!])
+    try @_p.set_bool(0xf, 0b00000100, Bool[other.targets_param_if_set!])
+    try @_p.set_bool(0xf, 0b00001000, Bool[other.targets_annotation_if_set!])
+
   :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(3, 3, 1))
   :fun ref type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(3, 3, 1))
   :fun ref set_type_to_point_to_existing(existing CapnProto.Meta.Type.Builder): CapnProto.Meta.Type.Builder.from_pointer(@_p.set_struct_to_point_to_existing(3, existing._p))
+  :fun ref copy_or_reference_type_data_from(other_field CapnProto.Meta.Type, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(3, 3, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Type.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_type_to_point_to_existing(CapnProto.Meta.Type.Builder.from_pointer(p))
+    )
 
   :fun targets_file: @_p.bool(0xe, 0b00000001)
   :fun targets_file_if_set!: @_p.bool_if_set!(0xe, 0b00000001)
@@ -1496,12 +1667,16 @@
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
   :fun ref copy_data_from(other CapnProto.Meta.Node.Parameter) None
+    try @_p.set_text(0, "\(other.name_if_set!)", "")
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Node.Parameter, cache CapnProto.ReferenceCache) None
     try @_p.set_text(0, "\(other.name_if_set!)", "")
 
   :fun ref name: @_p.text(0)
@@ -1516,12 +1691,17 @@
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
   :fun ref copy_data_from(other CapnProto.Meta.Node.NestedNode) None
+    try @_p.set_text(0, "\(other.name_if_set!)", "")
+    try @_p.set_u64(0x0, other.id_if_set!, 0)
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Node.NestedNode, cache CapnProto.ReferenceCache) None
     try @_p.set_text(0, "\(other.name_if_set!)", "")
     try @_p.set_u64(0x0, other.id_if_set!, 0)
 
@@ -1541,6 +1721,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :const no_discriminant U16: 65535
 
@@ -1556,6 +1737,15 @@
     try (other_slot = other.slot!, @init_slot.copy_data_from(other_slot))
     try (other_group = other.group!, @init_group.copy_data_from(other_group))
     try (other_ordinal = other.ordinal_if_set!, @ordinal.copy_data_from(other_ordinal))
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Field, cache CapnProto.ReferenceCache) None
+    try @_p.set_text(0, "\(other.name_if_set!)", "")
+    try @_p.set_u16(0x0, other.code_order_if_set!, 0)
+    try @init_annotations_and_copy_or_reference_data_from(other.annotations_if_set!, cache)
+    try @_p.set_u16(0x2, other.discriminant_value_if_set!, 65535)
+    try (other_slot = other.slot!, @init_slot.copy_or_reference_data_from(other_slot, cache))
+    try (other_group = other.group!, @init_group.copy_or_reference_data_from(other_group, cache))
+    try (other_ordinal = other.ordinal_if_set!, @ordinal.copy_or_reference_data_from(other_ordinal, cache))
 
   :fun ref name: @_p.text(0)
   :fun ref name_if_set!: @_p.text_if_set!(0)
@@ -1574,6 +1764,13 @@
     existing.each_with_index -> (existing_item, index |
       new_item = try (list[index]! | next)
       new_item.copy_data_from(existing_item)
+    )
+    list
+  :fun ref init_annotations_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.Annotation), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
     )
     list
   :fun ref trim_annotations(new_start, new_finish)
@@ -1613,6 +1810,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1624,6 +1822,12 @@
     try (other_default_value = other.default_value_if_set!, @default_value.copy_data_from(other_default_value))
     try @_p.set_bool(0x10, 0b00000001, Bool[other.had_explicit_default_if_set!])
 
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Field.AS_slot, cache CapnProto.ReferenceCache) None
+    try @_p.set_u32(0x4, other.offset_if_set!, 0)
+    try @copy_or_reference_type_data_from(other.type_if_set!, cache)
+    try @copy_or_reference_default_value_data_from(other.default_value_if_set!, cache)
+    try @_p.set_bool(0x10, 0b00000001, Bool[other.had_explicit_default_if_set!])
+
   :fun offset: @_p.u32(0x4)
   :fun offset_if_set!: @_p.u32_if_set!(0x4)
   :fun ref "offset="(new_value): @_p.set_u32(0x4, new_value, 0)
@@ -1631,10 +1835,32 @@
   :fun ref type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(2, 3, 1))
   :fun ref type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(2, 3, 1))
   :fun ref set_type_to_point_to_existing(existing CapnProto.Meta.Type.Builder): CapnProto.Meta.Type.Builder.from_pointer(@_p.set_struct_to_point_to_existing(2, existing._p))
+  :fun ref copy_or_reference_type_data_from(other_field CapnProto.Meta.Type, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(2, 3, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Type.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_type_to_point_to_existing(CapnProto.Meta.Type.Builder.from_pointer(p))
+    )
 
   :fun ref default_value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(3, 2, 1))
   :fun ref default_value_if_set!: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct_if_set!(3, 2, 1))
   :fun ref set_default_value_to_point_to_existing(existing CapnProto.Meta.Value.Builder): CapnProto.Meta.Value.Builder.from_pointer(@_p.set_struct_to_point_to_existing(3, existing._p))
+  :fun ref copy_or_reference_default_value_data_from(other_field CapnProto.Meta.Value, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(3, 2, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Value.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_default_value_to_point_to_existing(CapnProto.Meta.Value.Builder.from_pointer(p))
+    )
 
   :fun had_explicit_default: @_p.bool(0x10, 0b00000001)
   :fun had_explicit_default_if_set!: @_p.bool_if_set!(0x10, 0b00000001)
@@ -1648,12 +1874,16 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
   :fun ref copy_data_from(other CapnProto.Meta.Field.AS_group) None
+    try @_p.set_u64(0x10, other.type_id_if_set!, 0)
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Field.AS_group, cache CapnProto.ReferenceCache) None
     try @_p.set_u64(0x10, other.type_id_if_set!, 0)
 
   :fun type_id: @_p.u64(0x10)
@@ -1668,12 +1898,17 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 4
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
   :fun ref copy_data_from(other CapnProto.Meta.Field.AS_ordinal) None
+    if other.is_implicit @init_implicit
+    try @_p.set_u16(0xc, other.explicit!, 0)
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Field.AS_ordinal, cache CapnProto.ReferenceCache) None
     if other.is_implicit @init_implicit
     try @_p.set_u16(0xc, other.explicit!, 0)
 
@@ -1700,6 +1935,7 @@
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1709,6 +1945,11 @@
     try @_p.set_text(0, "\(other.name_if_set!)", "")
     try @_p.set_u16(0x0, other.code_order_if_set!, 0)
     try @init_annotations_and_copy_data_from(other.annotations_if_set!)
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Enumerant, cache CapnProto.ReferenceCache) None
+    try @_p.set_text(0, "\(other.name_if_set!)", "")
+    try @_p.set_u16(0x0, other.code_order_if_set!, 0)
+    try @init_annotations_and_copy_or_reference_data_from(other.annotations_if_set!, cache)
 
   :fun ref name: @_p.text(0)
   :fun ref name_if_set!: @_p.text_if_set!(0)
@@ -1729,6 +1970,13 @@
       new_item.copy_data_from(existing_item)
     )
     list
+  :fun ref init_annotations_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.Annotation), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
+    )
+    list
   :fun ref trim_annotations(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.trim_list(1, 1, 2, new_start, new_finish))
 
@@ -1740,6 +1988,7 @@
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1749,6 +1998,10 @@
     try @_p.set_u64(0x0, other.id_if_set!, 0)
     try (other_brand = other.brand_if_set!, @brand.copy_data_from(other_brand))
 
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Superclass, cache CapnProto.ReferenceCache) None
+    try @_p.set_u64(0x0, other.id_if_set!, 0)
+    try @copy_or_reference_brand_data_from(other.brand_if_set!, cache)
+
   :fun id: @_p.u64(0x0)
   :fun id_if_set!: @_p.u64_if_set!(0x0)
   :fun ref "id="(new_value): @_p.set_u64(0x0, new_value, 0)
@@ -1756,6 +2009,17 @@
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
   :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(0, 0, 1))
   :fun ref set_brand_to_point_to_existing(existing CapnProto.Meta.Brand.Builder): CapnProto.Meta.Brand.Builder.from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
+  :fun ref copy_or_reference_brand_data_from(other_field CapnProto.Meta.Brand, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(0, 0, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Brand.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_brand_to_point_to_existing(CapnProto.Meta.Brand.Builder.from_pointer(p))
+    )
 
 :struct CapnProto.Meta.Method.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -1765,6 +2029,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 5
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1779,6 +2044,16 @@
     try (other_param_brand = other.param_brand_if_set!, @param_brand.copy_data_from(other_param_brand))
     try (other_result_brand = other.result_brand_if_set!, @result_brand.copy_data_from(other_result_brand))
     try @init_implicit_parameters_and_copy_data_from(other.implicit_parameters_if_set!)
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Method, cache CapnProto.ReferenceCache) None
+    try @_p.set_text(0, "\(other.name_if_set!)", "")
+    try @_p.set_u16(0x0, other.code_order_if_set!, 0)
+    try @_p.set_u64(0x8, other.param_struct_type_if_set!, 0)
+    try @_p.set_u64(0x10, other.result_struct_type_if_set!, 0)
+    try @init_annotations_and_copy_or_reference_data_from(other.annotations_if_set!, cache)
+    try @copy_or_reference_param_brand_data_from(other.param_brand_if_set!, cache)
+    try @copy_or_reference_result_brand_data_from(other.result_brand_if_set!, cache)
+    try @init_implicit_parameters_and_copy_or_reference_data_from(other.implicit_parameters_if_set!, cache)
 
   :fun ref name: @_p.text(0)
   :fun ref name_if_set!: @_p.text_if_set!(0)
@@ -1807,16 +2082,45 @@
       new_item.copy_data_from(existing_item)
     )
     list
+  :fun ref init_annotations_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.Annotation), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.init_list(1, 1, 2, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
+    )
+    list
   :fun ref trim_annotations(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.Annotation.Builder).from_pointer(@_p.trim_list(1, 1, 2, new_start, new_finish))
 
   :fun ref param_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(2, 0, 1))
   :fun ref param_brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(2, 0, 1))
   :fun ref set_param_brand_to_point_to_existing(existing CapnProto.Meta.Brand.Builder): CapnProto.Meta.Brand.Builder.from_pointer(@_p.set_struct_to_point_to_existing(2, existing._p))
+  :fun ref copy_or_reference_param_brand_data_from(other_field CapnProto.Meta.Brand, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(2, 0, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Brand.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_param_brand_to_point_to_existing(CapnProto.Meta.Brand.Builder.from_pointer(p))
+    )
 
   :fun ref result_brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(3, 0, 1))
   :fun ref result_brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(3, 0, 1))
   :fun ref set_result_brand_to_point_to_existing(existing CapnProto.Meta.Brand.Builder): CapnProto.Meta.Brand.Builder.from_pointer(@_p.set_struct_to_point_to_existing(3, existing._p))
+  :fun ref copy_or_reference_result_brand_data_from(other_field CapnProto.Meta.Brand, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(3, 0, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Brand.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_result_brand_to_point_to_existing(CapnProto.Meta.Brand.Builder.from_pointer(p))
+    )
 
   :fun ref implicit_parameters: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list(4))
   :fun ref implicit_parameters_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.list_if_set!(4))
@@ -1827,6 +2131,13 @@
     existing.each_with_index -> (existing_item, index |
       new_item = try (list[index]! | next)
       new_item.copy_data_from(existing_item)
+    )
+    list
+  :fun ref init_implicit_parameters_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.Node.Parameter), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.Node.Parameter.Builder).from_pointer(@_p.init_list(4, 0, 1, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
     )
     list
   :fun ref trim_implicit_parameters(new_start, new_finish)
@@ -1840,6 +2151,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -1865,6 +2177,27 @@
     try (other_struct = other.struct!, @init_struct.copy_data_from(other_struct))
     try (other_interface = other.interface!, @init_interface.copy_data_from(other_interface))
     try (other_any_pointer = other.any_pointer!, @init_any_pointer.copy_data_from(other_any_pointer))
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Type, cache CapnProto.ReferenceCache) None
+    if other.is_void @init_void
+    if other.is_bool @init_bool
+    if other.is_int8 @init_int8
+    if other.is_int16 @init_int16
+    if other.is_int32 @init_int32
+    if other.is_int64 @init_int64
+    if other.is_uint8 @init_uint8
+    if other.is_uint16 @init_uint16
+    if other.is_uint32 @init_uint32
+    if other.is_uint64 @init_uint64
+    if other.is_float32 @init_float32
+    if other.is_float64 @init_float64
+    if other.is_text @init_text
+    if other.is_data @init_data
+    try (other_list = other.list!, @init_list.copy_or_reference_data_from(other_list, cache))
+    try (other_enum = other.enum!, @init_enum.copy_or_reference_data_from(other_enum, cache))
+    try (other_struct = other.struct!, @init_struct.copy_or_reference_data_from(other_struct, cache))
+    try (other_interface = other.interface!, @init_interface.copy_or_reference_data_from(other_interface, cache))
+    try (other_any_pointer = other.any_pointer!, @init_any_pointer.copy_or_reference_data_from(other_any_pointer, cache))
 
   :fun is_void: @_p.check_union(0x0, 0)
   :fun void!: @_p.assert_union!(0x0, 0), None
@@ -2014,6 +2347,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2022,9 +2356,23 @@
   :fun ref copy_data_from(other CapnProto.Meta.Type.AS_list) None
     try (other_element_type = other.element_type_if_set!, @element_type.copy_data_from(other_element_type))
 
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Type.AS_list, cache CapnProto.ReferenceCache) None
+    try @copy_or_reference_element_type_data_from(other.element_type_if_set!, cache)
+
   :fun ref element_type: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(0, 3, 1))
   :fun ref element_type_if_set!: CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(0, 3, 1))
   :fun ref set_element_type_to_point_to_existing(existing CapnProto.Meta.Type.Builder): CapnProto.Meta.Type.Builder.from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
+  :fun ref copy_or_reference_element_type_data_from(other_field CapnProto.Meta.Type, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(0, 3, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Type.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_element_type_to_point_to_existing(CapnProto.Meta.Type.Builder.from_pointer(p))
+    )
 
 :struct CapnProto.Meta.Type.AS_enum.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -2034,6 +2382,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2043,6 +2392,10 @@
     try @_p.set_u64(0x8, other.type_id_if_set!, 0)
     try (other_brand = other.brand_if_set!, @brand.copy_data_from(other_brand))
 
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Type.AS_enum, cache CapnProto.ReferenceCache) None
+    try @_p.set_u64(0x8, other.type_id_if_set!, 0)
+    try @copy_or_reference_brand_data_from(other.brand_if_set!, cache)
+
   :fun type_id: @_p.u64(0x8)
   :fun type_id_if_set!: @_p.u64_if_set!(0x8)
   :fun ref "type_id="(new_value): @_p.set_u64(0x8, new_value, 0)
@@ -2050,6 +2403,17 @@
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
   :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(0, 0, 1))
   :fun ref set_brand_to_point_to_existing(existing CapnProto.Meta.Brand.Builder): CapnProto.Meta.Brand.Builder.from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
+  :fun ref copy_or_reference_brand_data_from(other_field CapnProto.Meta.Brand, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(0, 0, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Brand.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_brand_to_point_to_existing(CapnProto.Meta.Brand.Builder.from_pointer(p))
+    )
 
 :struct CapnProto.Meta.Type.AS_struct.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -2059,6 +2423,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2068,6 +2433,10 @@
     try @_p.set_u64(0x8, other.type_id_if_set!, 0)
     try (other_brand = other.brand_if_set!, @brand.copy_data_from(other_brand))
 
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Type.AS_struct, cache CapnProto.ReferenceCache) None
+    try @_p.set_u64(0x8, other.type_id_if_set!, 0)
+    try @copy_or_reference_brand_data_from(other.brand_if_set!, cache)
+
   :fun type_id: @_p.u64(0x8)
   :fun type_id_if_set!: @_p.u64_if_set!(0x8)
   :fun ref "type_id="(new_value): @_p.set_u64(0x8, new_value, 0)
@@ -2075,6 +2444,17 @@
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
   :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(0, 0, 1))
   :fun ref set_brand_to_point_to_existing(existing CapnProto.Meta.Brand.Builder): CapnProto.Meta.Brand.Builder.from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
+  :fun ref copy_or_reference_brand_data_from(other_field CapnProto.Meta.Brand, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(0, 0, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Brand.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_brand_to_point_to_existing(CapnProto.Meta.Brand.Builder.from_pointer(p))
+    )
 
 :struct CapnProto.Meta.Type.AS_interface.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -2084,6 +2464,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2093,6 +2474,10 @@
     try @_p.set_u64(0x8, other.type_id_if_set!, 0)
     try (other_brand = other.brand_if_set!, @brand.copy_data_from(other_brand))
 
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Type.AS_interface, cache CapnProto.ReferenceCache) None
+    try @_p.set_u64(0x8, other.type_id_if_set!, 0)
+    try @copy_or_reference_brand_data_from(other.brand_if_set!, cache)
+
   :fun type_id: @_p.u64(0x8)
   :fun type_id_if_set!: @_p.u64_if_set!(0x8)
   :fun ref "type_id="(new_value): @_p.set_u64(0x8, new_value, 0)
@@ -2100,6 +2485,17 @@
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(0, 0, 1))
   :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(0, 0, 1))
   :fun ref set_brand_to_point_to_existing(existing CapnProto.Meta.Brand.Builder): CapnProto.Meta.Brand.Builder.from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
+  :fun ref copy_or_reference_brand_data_from(other_field CapnProto.Meta.Brand, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(0, 0, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Brand.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_brand_to_point_to_existing(CapnProto.Meta.Brand.Builder.from_pointer(p))
+    )
 
 :struct CapnProto.Meta.Type.AS_anyPointer.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -2109,6 +2505,7 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2118,6 +2515,11 @@
     try (other_unconstrained = other.unconstrained!, @init_unconstrained.copy_data_from(other_unconstrained))
     try (other_parameter = other.parameter!, @init_parameter.copy_data_from(other_parameter))
     try (other_implicit_method_parameter = other.implicit_method_parameter!, @init_implicit_method_parameter.copy_data_from(other_implicit_method_parameter))
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Type.AS_anyPointer, cache CapnProto.ReferenceCache) None
+    try (other_unconstrained = other.unconstrained!, @init_unconstrained.copy_or_reference_data_from(other_unconstrained, cache))
+    try (other_parameter = other.parameter!, @init_parameter.copy_or_reference_data_from(other_parameter, cache))
+    try (other_implicit_method_parameter = other.implicit_method_parameter!, @init_implicit_method_parameter.copy_or_reference_data_from(other_implicit_method_parameter, cache))
 
   :fun is_unconstrained: @_p.check_union(0x8, 0)
   :fun ref unconstrained!: @_p.assert_union!(0x8, 0), CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained.Builder.from_pointer(@_p)
@@ -2151,12 +2553,19 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
   :fun ref copy_data_from(other CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained) None
+    if other.is_any_kind @init_any_kind
+    if other.is_struct @init_struct
+    if other.is_list @init_list
+    if other.is_capability @init_capability
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Type.AS_anyPointer.AS_unconstrained, cache CapnProto.ReferenceCache) None
     if other.is_any_kind @init_any_kind
     if other.is_struct @init_struct
     if other.is_list @init_list
@@ -2198,12 +2607,17 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
   :fun ref copy_data_from(other CapnProto.Meta.Type.AS_anyPointer.AS_parameter) None
+    try @_p.set_u64(0x10, other.scope_id_if_set!, 0)
+    try @_p.set_u16(0xa, other.parameter_index_if_set!, 0)
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Type.AS_anyPointer.AS_parameter, cache CapnProto.ReferenceCache) None
     try @_p.set_u64(0x10, other.scope_id_if_set!, 0)
     try @_p.set_u16(0xa, other.parameter_index_if_set!, 0)
 
@@ -2223,12 +2637,16 @@
   :const capn_proto_data_word_count U16: 3
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
   :fun ref copy_data_from(other CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter) None
+    try @_p.set_u16(0xa, other.parameter_index_if_set!, 0)
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Type.AS_anyPointer.AS_implicitMethodParameter, cache CapnProto.ReferenceCache) None
     try @_p.set_u16(0xa, other.parameter_index_if_set!, 0)
 
   :fun parameter_index: @_p.u16(0xa)
@@ -2243,6 +2661,7 @@
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2250,6 +2669,9 @@
 
   :fun ref copy_data_from(other CapnProto.Meta.Brand) None
     try @init_scopes_and_copy_data_from(other.scopes_if_set!)
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Brand, cache CapnProto.ReferenceCache) None
+    try @init_scopes_and_copy_or_reference_data_from(other.scopes_if_set!, cache)
 
   :fun ref scopes: CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.list(0))
   :fun ref scopes_if_set!: CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.list_if_set!(0))
@@ -2260,6 +2682,13 @@
     existing.each_with_index -> (existing_item, index |
       new_item = try (list[index]! | next)
       new_item.copy_data_from(existing_item)
+    )
+    list
+  :fun ref init_scopes_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.Brand.Scope), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.Brand.Scope.Builder).from_pointer(@_p.init_list(0, 2, 1, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
     )
     list
   :fun ref trim_scopes(new_start, new_finish)
@@ -2273,6 +2702,7 @@
   :const capn_proto_data_word_count U16: 2
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2281,6 +2711,11 @@
   :fun ref copy_data_from(other CapnProto.Meta.Brand.Scope) None
     try @_p.set_u64(0x0, other.scope_id_if_set!, 0)
     try @init_bind_and_copy_data_from(other.bind!)
+    if other.is_inherit @init_inherit
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Brand.Scope, cache CapnProto.ReferenceCache) None
+    try @_p.set_u64(0x0, other.scope_id_if_set!, 0)
+    try @init_bind_and_copy_or_reference_data_from(other.bind!, cache)
     if other.is_inherit @init_inherit
 
   :fun scope_id: @_p.u64(0x0)
@@ -2301,6 +2736,14 @@
       new_item.copy_data_from(existing_item)
     )
     list
+  :fun ref init_bind_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.Brand.Binding), cache CapnProto.ReferenceCache)
+    @_p.mark_union(0x8, 0)
+    list = CapnProto.List.Builder(CapnProto.Meta.Brand.Binding.Builder).from_pointer(@_p.init_list(0, 1, 1, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
+    )
+    list
 
   :fun is_inherit: @_p.check_union(0x8, 1)
   :fun inherit!: @_p.assert_union!(0x8, 1), None
@@ -2317,6 +2760,7 @@
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2325,6 +2769,10 @@
   :fun ref copy_data_from(other CapnProto.Meta.Brand.Binding) None
     if other.is_unbound @init_unbound
     try (other_type = other.type!, @init_type.copy_data_from(other_type))
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Brand.Binding, cache CapnProto.ReferenceCache) None
+    if other.is_unbound @init_unbound
+    try @copy_or_reference_type_data_from(other.type!, cache)
 
   :fun is_unbound: @_p.check_union(0x0, 0)
   :fun unbound!: @_p.assert_union!(0x0, 0), None
@@ -2336,6 +2784,18 @@
   :fun is_type: @_p.check_union(0x0, 1)
   :fun ref type!: @_p.assert_union!(0x0, 1), CapnProto.Meta.Type.Builder.from_pointer(@_p.struct(0, 3, 1))
   :fun ref type_if_set!: @_p.assert_union!(0x0, 1), CapnProto.Meta.Type.Builder.from_pointer(@_p.struct_if_set!(0, 3, 1))
+  :fun ref set_type_to_point_to_existing(existing CapnProto.Meta.Type.Builder): CapnProto.Meta.Type.Builder.from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
+  :fun ref copy_or_reference_type_data_from(other_field CapnProto.Meta.Type, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(0, 3, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Type.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_type_to_point_to_existing(CapnProto.Meta.Type.Builder.from_pointer(p))
+    )
   :fun ref init_type
     @_p.clear_pointer(0) // type
     @_p.mark_union(0x0, 1)
@@ -2349,12 +2809,31 @@
   :const capn_proto_data_word_count U16: 2
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
   :fun ref copy_data_from(other CapnProto.Meta.Value) None
+    if other.is_void @init_void
+    try @_p.set_bool(0x2, 0b00000001, Bool[other.bool!])
+    try @_p.set_i8(0x2, other.int8!, 0)
+    try @_p.set_i16(0x2, other.int16!, 0)
+    try @_p.set_i32(0x4, other.int32!, 0)
+    try @_p.set_i64(0x8, other.int64!, 0)
+    try @_p.set_u8(0x2, other.uint8!, 0)
+    try @_p.set_u16(0x2, other.uint16!, 0)
+    try @_p.set_u32(0x4, other.uint32!, 0)
+    try @_p.set_u64(0x8, other.uint64!, 0)
+    try @_p.set_f32(0x4, other.float32!, 0.0)
+    try @_p.set_f64(0x8, other.float64!, 0.0)
+    try @_p.set_text(0, "\(other.text!)", "")
+    try @_p.set_data(0, "\(other.data!)".as_bytes, b"")
+    try @_p.set_u16(0x2, other.enum!, 0)
+    if other.is_interface @init_interface
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Value, cache CapnProto.ReferenceCache) None
     if other.is_void @init_void
     try @_p.set_bool(0x2, 0b00000001, Bool[other.bool!])
     try @_p.set_i8(0x2, other.int8!, 0)
@@ -2527,6 +3006,7 @@
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2537,6 +3017,11 @@
     try (other_value = other.value_if_set!, @value.copy_data_from(other_value))
     try (other_brand = other.brand_if_set!, @brand.copy_data_from(other_brand))
 
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.Annotation, cache CapnProto.ReferenceCache) None
+    try @_p.set_u64(0x0, other.id_if_set!, 0)
+    try @copy_or_reference_value_data_from(other.value_if_set!, cache)
+    try @copy_or_reference_brand_data_from(other.brand_if_set!, cache)
+
   :fun id: @_p.u64(0x0)
   :fun id_if_set!: @_p.u64_if_set!(0x0)
   :fun ref "id="(new_value): @_p.set_u64(0x0, new_value, 0)
@@ -2544,10 +3029,32 @@
   :fun ref value: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct(0, 2, 1))
   :fun ref value_if_set!: CapnProto.Meta.Value.Builder.from_pointer(@_p.struct_if_set!(0, 2, 1))
   :fun ref set_value_to_point_to_existing(existing CapnProto.Meta.Value.Builder): CapnProto.Meta.Value.Builder.from_pointer(@_p.set_struct_to_point_to_existing(0, existing._p))
+  :fun ref copy_or_reference_value_data_from(other_field CapnProto.Meta.Value, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(0, 2, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Value.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_value_to_point_to_existing(CapnProto.Meta.Value.Builder.from_pointer(p))
+    )
 
   :fun ref brand: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct(1, 0, 1))
   :fun ref brand_if_set!: CapnProto.Meta.Brand.Builder.from_pointer(@_p.struct_if_set!(1, 0, 1))
   :fun ref set_brand_to_point_to_existing(existing CapnProto.Meta.Brand.Builder): CapnProto.Meta.Brand.Builder.from_pointer(@_p.set_struct_to_point_to_existing(1, existing._p))
+  :fun ref copy_or_reference_brand_data_from(other_field CapnProto.Meta.Brand, cache CapnProto.ReferenceCache) None
+    is_new = False
+    p = cache.struct(other_field.capn_proto_absolute_address) -> (
+      is_new = True
+      @_p.struct(1, 0, 1)
+    )
+    if is_new (
+      CapnProto.Meta.Brand.Builder.from_pointer(p).copy_or_reference_data_from(other_field, cache)
+    |
+      @set_brand_to_point_to_existing(CapnProto.Meta.Brand.Builder.from_pointer(p))
+    )
 
 :struct CapnProto.Meta.CodeGeneratorRequest.Builder
   :let _p CapnProto.Pointer.Struct.Builder
@@ -2557,6 +3064,7 @@
   :const capn_proto_data_word_count U16: 0
   :const capn_proto_pointer_count U16: 2
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2565,6 +3073,10 @@
   :fun ref copy_data_from(other CapnProto.Meta.CodeGeneratorRequest) None
     try @init_nodes_and_copy_data_from(other.nodes_if_set!)
     try @init_requested_files_and_copy_data_from(other.requested_files_if_set!)
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.CodeGeneratorRequest, cache CapnProto.ReferenceCache) None
+    try @init_nodes_and_copy_or_reference_data_from(other.nodes_if_set!, cache)
+    try @init_requested_files_and_copy_or_reference_data_from(other.requested_files_if_set!, cache)
 
   :fun ref nodes: CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.list(0))
   :fun ref nodes_if_set!: CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.list_if_set!(0))
@@ -2575,6 +3087,13 @@
     existing.each_with_index -> (existing_item, index |
       new_item = try (list[index]! | next)
       new_item.copy_data_from(existing_item)
+    )
+    list
+  :fun ref init_nodes_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.Node), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.Node.Builder).from_pointer(@_p.init_list(0, 5, 6, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
     )
     list
   :fun ref trim_nodes(new_start, new_finish)
@@ -2591,6 +3110,13 @@
       new_item.copy_data_from(existing_item)
     )
     list
+  :fun ref init_requested_files_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.CodeGeneratorRequest.RequestedFile), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.init_list(1, 1, 2, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
+    )
+    list
   :fun ref trim_requested_files(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Builder).from_pointer(@_p.trim_list(1, 1, 2, new_start, new_finish))
 
@@ -2602,6 +3128,7 @@
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 2
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
@@ -2611,6 +3138,11 @@
     try @_p.set_u64(0x0, other.id_if_set!, 0)
     try @_p.set_text(0, "\(other.filename_if_set!)", "")
     try @init_imports_and_copy_data_from(other.imports_if_set!)
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.CodeGeneratorRequest.RequestedFile, cache CapnProto.ReferenceCache) None
+    try @_p.set_u64(0x0, other.id_if_set!, 0)
+    try @_p.set_text(0, "\(other.filename_if_set!)", "")
+    try @init_imports_and_copy_or_reference_data_from(other.imports_if_set!, cache)
 
   :fun id: @_p.u64(0x0)
   :fun id_if_set!: @_p.u64_if_set!(0x0)
@@ -2631,6 +3163,13 @@
       new_item.copy_data_from(existing_item)
     )
     list
+  :fun ref init_imports_and_copy_or_reference_data_from(existing CapnProto.List(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import), cache CapnProto.ReferenceCache)
+    list = CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).from_pointer(@_p.init_list(1, 1, 1, existing.size))
+    existing.each_with_index -> (existing_item, index |
+      new_item = try (list[index]! | next)
+      new_item.copy_or_reference_data_from(existing_item, cache)
+    )
+    list
   :fun ref trim_imports(new_start, new_finish)
     CapnProto.List.Builder(CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import.Builder).from_pointer(@_p.trim_list(1, 1, 1, new_start, new_finish))
 
@@ -2642,12 +3181,17 @@
   :const capn_proto_data_word_count U16: 1
   :const capn_proto_pointer_count U16: 1
   :fun capn_proto_address U64: @_p.capn_proto_address
+  :fun capn_proto_absolute_address USize: @_p.absolute_address
 
   :is TraceData
   :fun trace_data(trace TraceData.Observer)
     @as_reader.trace_data(trace)
 
   :fun ref copy_data_from(other CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import) None
+    try @_p.set_u64(0x0, other.id_if_set!, 0)
+    try @_p.set_text(0, "\(other.name_if_set!)", "")
+
+  :fun ref copy_or_reference_data_from(other CapnProto.Meta.CodeGeneratorRequest.RequestedFile.Import, cache CapnProto.ReferenceCache) None
     try @_p.set_u64(0x0, other.id_if_set!, 0)
     try @_p.set_text(0, "\(other.name_if_set!)", "")
 

--- a/src/CapnProto.ReferenceCache.savi
+++ b/src/CapnProto.ReferenceCache.savi
@@ -1,0 +1,8 @@
+:class CapnProto.ReferenceCache
+  :let _structs: Map(USize, CapnProto.Pointer.Struct.Builder).new
+
+  :fun ref struct(absolute_address USize)
+    :yields None for CapnProto.Pointer.Struct.Builder
+    @_structs.get_or_insert(absolute_address) -> (
+      yield None
+    )

--- a/src/capnpc-savi/_Gen.savi
+++ b/src/capnpc-savi/_Gen.savi
@@ -243,6 +243,7 @@
         struct.pointer_count
       )"
       @_out << "\n  :fun capn_proto_address U64: @_p.capn_proto_address"
+      @_out << "\n  :fun capn_proto_absolute_address USize: @_p.absolute_address"
     )
 
     // Emit constant values.
@@ -261,7 +262,10 @@
 
     // Emit data tracing methods.
     @_emit_trace_data(node, is_builder)
-    if is_builder @_emit_copy_data_from(node)
+    if is_builder (
+      @_emit_copy_data_from(node, False)
+      @_emit_copy_data_from(node, True)
+    )
 
     // Emit field accessor methods.
     fields = try (node.struct!.fields | return)
@@ -274,6 +278,7 @@
         try @_emit_field_setter!(node, field)
         try @_emit_field_list_initter!(node, field)
         try @_emit_field_list_initter!(node, field, True)
+        try @_emit_field_list_initter!(node, field, True, True)
         try @_emit_field_list_trimmer!(node, field)
         try @_emit_field_union_initter!(node, field)
       )
@@ -320,13 +325,14 @@
       @_out << "\n    )"
     )
 
-  :fun ref _emit_copy_data_from(node CapnProto.Meta.Node)
+  :fun ref _emit_copy_data_from(node CapnProto.Meta.Node, try_reference Bool)
     // TODO: It should be possible to copy data (without knowing the schema
     // of every type we're copying) at the underlying pointer level.
     // This would be a more efficient and ultimately simpler way to copy data,
     // but it would require additional time investment that isn't important now.
+    copy_data_fn_name val = "copy\(if try_reference "_or_reference")_data_from"
 
-    @_out << "\n\n  :fun ref copy_data_from(other \(
+    @_out << "\n\n  :fun ref \(copy_data_fn_name)(other \(
       @_node_scoped_name(node)
     )\(
       if node.parameters.size > 0 "\(
@@ -336,6 +342,8 @@
         )
         "(\(String.join(param_names, ", ")))"
       )"
+    )\(
+      if try_reference ", cache CapnProto.ReferenceCache"
     )) None"
 
     try node.struct!.fields.each -> (field |
@@ -346,7 +354,7 @@
 
       slot = try (field.slot! |
         // If the field is not a slot, it must be a group.
-        @_out << "\n    try (other_\(name) = other.\(name)\(get_suffix)!, @\(init_prefix)\(name).copy_data_from(other_\(name)))"
+        @_out << "\n    try (other_\(name) = other.\(name)\(get_suffix)!, @\(init_prefix)\(name).\(copy_data_fn_name)(other_\(name)\(if try_reference ", cache")))"
         next
       )
 
@@ -356,7 +364,11 @@
           @_out << "\n    if other.is_\(name) @init_\(name)"
         )
       | slot.type.is_struct |
-        @_out << "\n    try (other_\(name) = other.\(name)\(get_suffix)!, @\(init_prefix)\(name).copy_data_from(other_\(name)))"
+        if try_reference (
+          @_out << "\n    try @copy_or_reference_\(name)_data_from(other.\(name)\(get_suffix)!, cache)"
+        |
+          @_out << "\n    try (other_\(name) = other.\(name)\(get_suffix)!, @\(init_prefix)\(name).\(copy_data_fn_name)(other_\(name)\(if try_reference ", cache")))"
+        )
       | slot.type.is_text |
         @_out << "\n    try "
         @_emit_field_set_expr(field, "\"\\(other.\(name)\(get_suffix)!)\"") // TODO: avoid intermediate string copy
@@ -364,7 +376,7 @@
         @_out << "\n    try "
         @_emit_field_set_expr(field, "\"\\(other.\(name)\(get_suffix)!)\".as_bytes") // TODO: avoid intermediate string copy
       | slot.type.is_list |
-        @_out << "\n    try @init_\(name)_and_copy_data_from(other.\(name)\(get_suffix)!)"
+        @_out << "\n    try @init_\(name)_and_\(copy_data_fn_name)(other.\(name)\(get_suffix)!\(if try_reference ", cache"))"
       | @_is_pointer_type(slot.type) | // TODO: handle other pointer types
       |
         @_out << "\n    try "
@@ -410,9 +422,6 @@
     node CapnProto.Meta.Node
     field CapnProto.Meta.Field
   )
-    is_union = field.discriminant_value != field.no_discriminant
-    error! if is_union
-
     slot = field.slot!
     // TODO: Implement other pointer-sharing setter options
     error! if (
@@ -424,21 +433,47 @@
     )
 
     if slot.type.is_struct (
+      snake_case_name = _TextCase.Snake[field.name]
       @_out << "\n  :fun ref set_\(
-        _TextCase.Snake[field.name]
+        snake_case_name
       )_to_point_to_existing(existing \(
         @_type_name(slot.type, True)
       )): "
       @_emit_field_set_to_point_to_existing_expr(field, "existing._p")
+
+      @_out << "\n  :fun ref copy_or_reference_\(
+        snake_case_name
+      )_data_from(other_field \(
+        @_type_name(slot.type, False)
+      ), cache CapnProto.ReferenceCache) None"
+
+      try (
+        struct = @_find_node!(slot.type.struct!.type_id).struct!
+
+        @_out << "\n    is_new = False"
+        @_out << "\n    p = cache.struct(other_field.capn_proto_absolute_address) -> ("
+        @_out << "\n      is_new = True"
+        @_out << "\n      @_p.struct(\(slot.offset), \(struct.data_word_count), \(struct.pointer_count))"
+        @_out << "\n    )"
+        @_out << "\n    if is_new ("
+        @_out << "\n      \(@_type_name(slot.type, True)).from_pointer(p).copy_or_reference_data_from(other_field, cache)"
+        @_out << "\n    |"
+        @_out << "\n      @set_\(snake_case_name)_to_point_to_existing(\(@_type_name(slot.type, True)).from_pointer(p))"
+        @_out << "\n    )"
+      )
     |
-      @_out << "\n  :fun ref \"\(_TextCase.Snake[field.name])=\"(new_value): "
-      @_emit_field_set_expr(field, "new_value")
+      is_not_union = field.discriminant_value == field.no_discriminant
+      if is_not_union (
+        @_out << "\n  :fun ref \"\(_TextCase.Snake[field.name])=\"(new_value): "
+        @_emit_field_set_expr(field, "new_value")
+      )
     )
 
   :fun ref _emit_field_list_initter!(
     node CapnProto.Meta.Node
     field CapnProto.Meta.Field
     is_copy Bool = False
+    try_reference Bool = False
   )
     slot = field.slot!
     type = slot.type
@@ -449,11 +484,20 @@
     suffix = ""
     params = "new_count"
     init_list_args = "new_count"
+    copy_from_args = ""
 
     if is_copy (
-      suffix = "_and_copy_data_from"
-      params = "existing \(@_type_name(type, False))"
-      init_list_args = "existing.size"
+      if try_reference (
+        suffix = "_and_copy_or_reference_data_from"
+        params = "existing \(@_type_name(type, False)), cache CapnProto.ReferenceCache"
+        init_list_args = "existing.size"
+        copy_from_args = "existing_item, cache"
+      |
+        suffix = "_and_copy_data_from"
+        params = "existing \(@_type_name(type, False))"
+        init_list_args = "existing.size"
+        copy_from_args = "existing_item"
+      )
     )
 
     @_out << "\n  :fun ref init_\(
@@ -487,7 +531,7 @@
     if is_copy (
       @_out << "\n    existing.each_with_index -> (existing_item, index |"
       @_out << "\n      new_item = try (list[index]! | next)"
-      @_out << "\n      new_item.copy_data_from(existing_item)"
+      @_out << "\n      new_item.copy\(if try_reference "_or_reference")_data_from(\(copy_from_args))"
       @_out << "\n    )"
       @_out << "\n    list"
     )
@@ -596,7 +640,7 @@
     field CapnProto.Meta.Field
     is_builder Bool
     is_get_if_set Bool
-  )
+  ) None
     suffix = if is_get_if_set ("_if_set!" | "")
 
     // First, handle the case where the field is a group instead of a slot.


### PR DESCRIPTION
Also add `capn_proto_absolute_address` methods to compare the absolute pointer address of structs.